### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ If you plan to use this module for submitting metadata, please ensure you comply
 Import the module
 JavaScript example, how to import 'musicbrainz-api:
 ```javascript
-const MusicbrainzApi = require('musicbrainz-api').MusicbrainzApi;
+const MusicBrainzApi = require('musicbrainz-api').MusicBrainzApi;
 
-const mbApi = new MusicbrainzApi({
+const mbApi = new MusicBrainzApi({
   appName: 'my-app',
   appVersion: '0.1.0',
   appContactInfo: 'user@mail.org'


### PR DESCRIPTION
Node throws "TypeError: MusicbrainzApi is not a constructor" when using the example in README.md. This is because MusicbrainzApi has a lower-case b and is undefined. It should be a capital B.