### PR TITLE
Fix broken documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ const mbApi = new MusicbrainzApi(config);
 
 ## Lookup MusicBrainz Entities
 
-MusicBrainz API documentation: [XML Web Service/Version 2 Lookups](https://wiki.musicbrainz.org/Development/XML_Web_Service/Version_2/#Lookups)
+MusicBrainz API documentation: [XML Web Service/Version 2 Lookups](https://wiki.musicbrainz.org/Development/XML_Web_Service/Version_2#Lookups)
 
 ### Generic lookup function
 


### PR DESCRIPTION
Noticed this URL was broken while reading the documentation, thought I'd submit a fix for it.

Any issues, let me know.