### PR TITLE
Add Genres to Includes Type

### DIFF
--- a/src/musicbrainz-api.ts
+++ b/src/musicbrainz-api.ts
@@ -49,7 +49,8 @@ export type Includes =
   | 'release-rels'
   | 'release-group-rels'
   | 'series-rels'
-  | 'work-rels';
+  | 'work-rels'
+  | 'genres';
 
 const debug = Debug('musicbrainz-api');
 


### PR DESCRIPTION
I recently attempted to pull a release group w/ genres by including `genres` however this doesn't work at the `Includes` type doesn't include this.

https://beta.musicbrainz.org/ws/2/release-group/03345972-d2f8-36bb-b49a-03a9ceccb7a7?inc=genres&fmt=json

<img width="789" alt="Screen Shot 2021-04-19 at 1 18 39 PM" src="https://user-images.githubusercontent.com/192464/115277114-e006f380-a111-11eb-8080-2cbf4b2cb4e5.png">
