### PR TITLE
Be able to choose between query & browse API

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you plan to use this module for submitting metadata, please ensure you comply
 
 Import the module
 JavaScript example, how to import 'musicbrainz-api:
-```javascript
+```js
 const MusicBrainzApi = require('musicbrainz-api').MusicBrainzApi;
 
 const mbApi = new MusicBrainzApi({
@@ -43,7 +43,7 @@ const mbApi = new MusicBrainzApi({
 ```
 
 In TypeScript you it would look like this:
-```javascript
+```js
 import {MusicBrainzApi} from 'musicbrainz-api';
 
 const mbApi = new MusicBrainzApi({
@@ -54,7 +54,7 @@ const mbApi = new MusicBrainzApi({
 ```
 
 The following configuration settings can be passed 
-```javascript
+```js
 import {MusicBrainzApi} from '../src/musicbrainz-api';
 
 const config = {
@@ -93,49 +93,55 @@ Arguments:
 *   entity: `'artist'` | `'label'` | `'recording'` | `'release'` | `'release-group'` | `'work'` | `'area'` | `'url'`
 *   MBID [(MusicBrainz identifier)](https://wiki.musicbrainz.org/MusicBrainz_Identifier)
 
-```javascript
-const artist = await mbApi.getEntity('artist', 'ab2528d9-719f-4261-8098-21849222a0f2');
+```js
+const artist = await mbApi.getEntity('artist', {query: 'ab2528d9-719f-4261-8098-21849222a0f2'});
 ```
 
 ### Lookup area
 
-```javascript
-const area = await mbApi.getArea('ab2528d9-719f-4261-8098-21849222a0f2');
+```js
+const area = await mbApi.getArea({query: 'ab2528d9-719f-4261-8098-21849222a0f2'});
 ```
 
 ### Lookup artist
 
 Lookup an `artist` and include their `releases`, `release-groups` and `aliases`
 
-```javascript
-const artist = await mbApi.getArtist('ab2528d9-719f-4261-8098-21849222a0f2');
+```js
+const artist = await mbApi.getArtist({query: 'ab2528d9-719f-4261-8098-21849222a0f2'});
+```
+
+or use the browse API:
+
+```js
+const artist = await mbApi.getArtist({artist: 'ab2528d9-719f-4261-8098-21849222a0f2'});
 ```
 
 The second argument can be used to pass [subqueries](https://wiki.musicbrainz.org/Development/XML_Web_Service/Version_2#Subqueries), which will return more (nested) information:
-```javascript
+```js
 const artist = await mbApi.getArtist('ab2528d9-719f-4261-8098-21849222a0f2', ['releases', 'recordings', 'url-rels']);
 ```
 
 ### Lookup recording
 
 The second argument can be used to pass [subqueries](https://wiki.musicbrainz.org/Development/XML_Web_Service/Version_2#Subqueries):
-```javascript
-const artist = await mbApi.getRecording('16afa384-174e-435e-bfa3-5591accda31c', ['artists', 'url-rels']);
+```js
+const artist = await mbApi.getRecording({query: '16afa384-174e-435e-bfa3-5591accda31c'}, ['artists', 'url-rels']);
 ```
 
 ### Lookup release
-```javascript
-const release = await mbApi.getRelease('976e0677-a480-4a5e-a177-6a86c1900bbf', ['artists', 'url-rels']);
+```js
+const release = await mbApi.getRelease({query: '976e0677-a480-4a5e-a177-6a86c1900bbf'}, ['artists', 'url-rels']);
 ```
 
 ### Lookup release-group
-```javascript
-const releaseGroup = await mbApi.getReleaseGroup('19099ea5-3600-4154-b482-2ec68815883e');
+```js
+const releaseGroup = await mbApi.getReleaseGroup({query: '19099ea5-3600-4154-b482-2ec68815883e'});
 ```
 
 ### Lookup work
-```javascript
-const work = await mbApi.getWork('b2aa02f4-6c95-43be-a426-aedb9f9a3805');
+```js
+const work = await mbApi.getWork({query: 'b2aa02f4-6c95-43be-a426-aedb9f9a3805'});
 ```
 
 ## Search (query)
@@ -164,28 +170,28 @@ Arguments:
     *   `limit.query`: optional, an integer value defining how many entries should be returned. Only values between 1 and 100 (both inclusive) are allowed. If not given, this defaults to 25.
 
 For example, to find any recordings of _'We Will Rock You'_ by Queen:
-```javascript
+```js
 const query = 'query="We Will Rock You" AND arid:0383dadf-2a4e-4d10-a46a-e9e041da8eb3';
 const result = await mbApi.query<mb.IReleaseGroupList>('release-group', {query});
 ```
 
 ##### Example: search Île-de-France
 
-```javascript
+```js
  mbApi.search('area', 'Île-de-France');
 ````
 
 ##### Example: search release by barcode
 
 Search a release with the barcode 602537479870:
-```javascript
- mbApi.search('release', {barcode: 602537479870});
+```js
+ mbApi.search('release', {query: {barcode: 602537479870}});
 ````
 
 ##### Example: search by object
 
 Same as previous example, but automatically serialize parameters to search query
-```javascript
+```js
  mbApi.search('release', 'barcode: 602537479870');
 ````
 
@@ -198,17 +204,17 @@ searchReleaseGroup(query: string | IFormData, offset?: number, limit?: number): 
 ```
 
 Search artist:
-```javascript
-const result = await mbApi.searchArtist('Stromae');
+```js
+const result = await mbApi.searchArtist({query: 'Stromae'});
 ```
 
 Search release-group:
-```javascript
-const result = await mbApi.searchReleaseGroup('Racine carrée');
+```js
+const result = await mbApi.searchReleaseGroup({query: 'Racine carrée'});
 ```
 
 Search a combination of a release-group and an artist.
-```javascript
+```js
 const result = await mbApi.searchReleaseGroup({artist: 'Racine carrée', releasegroup: 'Stromae'});
 ```
 
@@ -220,7 +226,7 @@ const result = await mbApi.searchReleaseGroup({artist: 'Racine carrée', release
 
 Using the [XML ISRC submission](https://wiki.musicbrainz.org/Development/XML_Web_Service/Version_2#ISRC_submission) API.
 
-```javascript
+```js
 const mbid_Formidable = '16afa384-174e-435e-bfa3-5591accda31c';
 const isrc_Formidable = 'BET671300161';
 
@@ -239,7 +245,7 @@ For all of the following function you need to use a dedicated bot account.
 <img width="150" src="http://www.clker.com/cliparts/i/w/L/q/u/1/work-in-progress.svg"/>
 Use with caution, and only on a test server, it may clear existing metadata as side effect.
       
-```javascript
+```js
 
 const mbid_Formidable = '16afa384-174e-435e-bfa3-5591accda31c';
 const isrc_Formidable = 'BET671300161';
@@ -257,7 +263,7 @@ await mbApi.addIsrc(recording, isrc_Formidable);
 
 ### Submit recording URL
 
-```javascript
+```js
 const recording = await mbApi.getRecording('16afa384-174e-435e-bfa3-5591accda31c');
 
 const succeed = await mbApi.login();
@@ -270,7 +276,7 @@ await mbApi.addUrlToRecording(recording, {
 ```
 
 Actually a Spotify-track-ID can be submitted easier: 
-```javascript
+```js
 const recording = await mbApi.getRecording('16afa384-174e-435e-bfa3-5591accda31c');
 
 const succeed = await mbApi.login();

--- a/src/musicbrainz-api.ts
+++ b/src/musicbrainz-api.ts
@@ -473,14 +473,14 @@ export class MusicBrainzApi {
    * Search an entity using a search query
    * @param query e.g.: '" artist: Madonna, track: Like a virgin"' or object with search terms: {artist: Madonna}
    * @param entity e.g. 'recording'
-   * @param offset
-   * @param limit
+   * @param query Arguments
    */
-  public search<T extends mb.ISearchResult>(entity: mb.EntityType, query: string | IFormData, offset?: number, limit?: number): Promise<T> {
-    if (typeof query === 'object') {
-      query = makeAndQueryString(query);
+  public search<T extends mb.ISearchResult>(entity: mb.EntityType, query: mb.ISearchQuery): Promise<T> {
+    const urlQuery = {...query};
+    if (typeof query.query === 'object') {
+      urlQuery.query = makeAndQueryString(query.query);
     }
-    return this.restGet<T>('/' + entity + '/', {query, offset, limit});
+    return this.restGet<T>('/' + entity + '/', urlQuery);
   }
 
   // -----------------------------------------------------------------------------------------------------------------
@@ -504,24 +504,24 @@ export class MusicBrainzApi {
     }, editNote);
   }
 
-  public searchArtist(query: string | IFormData, offset?: number, limit?: number): Promise<mb.IArtistList> {
-    return this.search<mb.IArtistList>('artist', query, offset, limit);
+  public searchArea(query: mb.ISearchQuery & mb.ILinkedEntitiesArea): Promise<mb.IAreaList> {
+    return this.search<mb.IAreaList>('area', query);
   }
 
-  public searchRelease(query: string | IFormData, offset?: number, limit?: number): Promise<mb.IReleaseList> {
-    return this.search<mb.IReleaseList>('release', query, offset, limit);
+  public searchArtist(query: mb.ISearchQuery & mb.ILinkedEntitiesArtist): Promise<mb.IArtistList> {
+    return this.search<mb.IArtistList>('artist', query);
   }
 
-  public searchReleaseGroup(query: string | IFormData, offset?: number, limit?: number): Promise<mb.IReleaseGroupList> {
-    return this.search<mb.IReleaseGroupList>('release-group', query, offset, limit);
+  public searchRelease(query: mb.ISearchQuery & mb.ILinkedEntitiesRelease): Promise<mb.IReleaseList> {
+    return this.search<mb.IReleaseList>('release', query);
   }
 
-  public searchArea(query: string | IFormData, offset?: number, limit?: number): Promise<mb.IAreaList> {
-    return this.search<mb.IAreaList>('area', query, offset, limit);
+  public searchReleaseGroup(query: mb.ISearchQuery & mb.ILinkedEntitiesReleaseGroup): Promise<mb.IReleaseGroupList> {
+    return this.search<mb.IReleaseGroupList>('release-group', query);
   }
 
-  public searchUrl(query: string | IFormData, offset?: number, limit?: number): Promise<mb.IUrlList> {
-    return this.search<mb.IUrlList>('url', query, offset, limit);
+  public searchUrl(query: mb.ISearchQuery & mb.ILinkedEntitiesUrl): Promise<mb.IUrlList> {
+    return this.search<mb.IUrlList>('url', query);
   }
 
   private async getSession(url: string): Promise<ISessionInformation> {

--- a/src/musicbrainz.types.ts
+++ b/src/musicbrainz.types.ts
@@ -1,4 +1,5 @@
 import DateTimeFormat = Intl.DateTimeFormat;
+import { IFormData, Includes } from './musicbrainz-api';
 
 export interface IPeriod {
   'begin': string,
@@ -308,5 +309,145 @@ export interface ISearchQuery extends IPagination {
   /**
    * Lucene search query, this is mandatory
    */
-  query: string;
+  query?: string | IFormData,
+  inc?: Includes[]
 }
+
+/**
+ * https://musicbrainz.org/doc/MusicBrainz_API#Browse
+ * /ws/2/area              collection
+ */
+export interface ILinkedEntitiesArea {
+  collection?: string;
+}
+
+/**
+ * https://musicbrainz.org/doc/MusicBrainz_API#Browse
+ * /ws/2/artist            area, collection, recording, release, release-group, work
+ */
+export interface ILinkedEntitiesArtist {
+  area?: string;
+  collection?: string;
+  recording?: string;
+  release?: string;
+  'release-group'?: string;
+  work?: string;
+}
+
+/**
+ * https://musicbrainz.org/doc/MusicBrainz_API#Browse
+ * /ws/2/collection        area, artist, editor, event, label, place, recording, release, release-group, work
+ */
+export interface ILinkedEntitiesCollection {
+  area?: string;
+  artist?: string;
+  editor?: string;
+  event?: string;
+  label?: string;
+  place?: string;
+  recording?: string;
+  release?: string;
+  'release-group'?: string;
+  work?: string;
+}
+
+/**
+ * https://musicbrainz.org/doc/MusicBrainz_API#Subqueries
+ * /ws/2/event             area, artist, collection, place
+ */
+export interface ILinkedEntitiesEvent {
+  area?: string;
+  artist?: string;
+  collection?: string;
+  place?: string;
+}
+
+/**
+ * https://musicbrainz.org/doc/MusicBrainz_API#Subqueries
+ * /ws/2/instrument        collection
+ */
+export interface ILinkedEntitiesInstrument {
+  collection?: string;
+}
+
+/**
+ * https://musicbrainz.org/doc/MusicBrainz_API#Subqueries
+ * /ws/2/label             area, collection, release
+ */
+export interface ILinkedEntitiesLabel {
+  area?: string;
+  collection?: string;
+  release?: string;
+}
+
+/**
+ * https://musicbrainz.org/doc/MusicBrainz_API#Subqueries
+ * /ws/2/place             area, collection
+ */
+export interface IBrowseArgumentPlace {
+  area?: string;
+  collection?: string;
+}
+
+/**
+ * https://musicbrainz.org/doc/MusicBrainz_API#Subqueries
+ * /ws/2/recording         artist, collection, release, work
+ */
+export interface ILinkedEntitiesRecording {
+  area?: string;
+  collection?: string;
+  release?: string;
+  work?: string;
+}
+
+/**
+ * https://musicbrainz.org/doc/MusicBrainz_API#Subqueries
+ * /ws/2/release           area, artist, collection, label, track, track_artist, recording, release-group
+ */
+export interface ILinkedEntitiesRelease {
+  area?: string;
+  artist?: string;
+  collection?: string;
+  label?: string;
+  track?: string;
+  track_artist?: string;
+  recording?: string;
+  'release-group'?: string;
+}
+
+/**
+ * https://musicbrainz.org/doc/MusicBrainz_API#Subqueries
+ * /ws/2/release-group     artist, collection, release
+ */
+export interface ILinkedEntitiesReleaseGroup {
+  artist?: string;
+  collection?: string;
+  release?: string;
+}
+
+/**
+ * https://musicbrainz.org/doc/MusicBrainz_API#Subqueries
+ * /ws/2/series            collection
+ */
+export interface ILinkedEntitiesSeries {
+  collection?: string;
+}
+
+/**
+ * https://musicbrainz.org/doc/MusicBrainz_API#Browse
+ * /ws/2/work              artist, collection
+ */
+export interface ILinkedEntitiesWork {
+  artist?: string;
+  collection?: string;
+}
+
+/**
+ * https://musicbrainz.org/doc/MusicBrainz_API#Browse
+ * /ws/2/url               resource
+ */
+export interface ILinkedEntitiesUrl {
+  resource?: string;
+}
+
+

--- a/test/test-musicbrainz-api.ts
+++ b/test/test-musicbrainz-api.ts
@@ -249,7 +249,7 @@ describe('MusicBrainz-api', function() {
       describe('generic search', () => {
 
         it('find artist: Stromae', async () => {
-          const result = await mbApi.search('artist', 'Stromae');
+          const result = await mbApi.search('artist', {query: 'Stromae'});
           assert.isAtLeast(result.count, 1);
         });
 
@@ -258,7 +258,7 @@ describe('MusicBrainz-api', function() {
       describe('searchArtist', () => {
 
         it('find artist: Stromae', async () => {
-          const result = await mbApi.searchArtist('Stromae');
+          const result = await mbApi.searchArtist({query: 'Stromae'});
           assert.isAtLeast(result.count, 1);
           assert.isAtLeast(result.artists.length, 1);
           assert.strictEqual(result.artists[0].id, mbid.artist.Stromae);
@@ -269,14 +269,14 @@ describe('MusicBrainz-api', function() {
       describe('searchReleaseGroup', () => {
 
         it('find release-group: Racine carrée', async () => {
-          const result = await mbApi.searchReleaseGroup('Racine carrée');
+          const result = await mbApi.searchReleaseGroup({query: 'Racine carrée'});
           assert.isAtLeast(result.count, 1);
           assert.isAtLeast(result['release-groups'].length, 1);
           assert.strictEqual(result['release-groups'][0].id, mbid.releaseGroup.RacineCarree);
         });
 
         it('find release-group: Racine carrée, by artist and group name', async () => {
-          const result = await mbApi.searchReleaseGroup({release: 'Racine carrée', artist: 'Stromae'});
+          const result = await mbApi.searchReleaseGroup({query: {release: 'Racine carrée', artist: 'Stromae'}});
           assert.isAtLeast(result.count, 1);
           assert.isAtLeast(result['release-groups'].length, 1);
           assert.strictEqual(result['release-groups'][0].id, mbid.releaseGroup.RacineCarree);
@@ -286,17 +286,38 @@ describe('MusicBrainz-api', function() {
       describe('searchRelease', () => {
 
         it('find release-group: Racine carrée', async () => {
-          const result = await mbApi.searchRelease({release: 'Racine carrée'});
+          const result = await mbApi.searchRelease({query: {release: 'Racine carrée'}});
           assert.isAtLeast(result.count, 2);
           assert.isAtLeast(result.releases.length, 2);
           assert.includeMembers(result.releases.map(release => release.id), mbid.release.RacineCarree);
         });
 
         it('find release by barcode', async () => {
-          const result = await mbApi.searchRelease({barcode: 602537479870});
+          const result = await mbApi.searchRelease({query: {barcode: 602537479870}});
           assert.isAtLeast(result.count, 1);
           assert.isAtLeast(result.releases.length, 1);
           assert.equal(result.releases[0].id, mbid.release.RacineCarree[2]);
+        });
+
+        it('find release by barcode', async () => {
+          const result = await mbApi.searchRelease({query: {barcode: 602537479870}});
+          assert.isAtLeast(result.count, 1);
+          assert.isAtLeast(result.releases.length, 1);
+          assert.equal(result.releases[0].id, mbid.release.RacineCarree[2]);
+        });
+
+        it('find releases by artist use query API', async () => {
+          const artist_mbid = 'eeb41a1e-4326-4d04-8c47-0f564ceecd68';
+          const result = await mbApi.searchRelease({query: {arid: artist_mbid} });
+          assert.isAtLeast(result.count, 1);
+          assert.isAtLeast(result.releases.length, 1);
+        });
+
+        it('find releases by artist use browse API', async () => {
+          const artist_mbid = 'eeb41a1e-4326-4d04-8c47-0f564ceecd68';
+          const result = await mbApi.searchRelease({artist:  artist_mbid});
+          assert.isAtLeast(result['release-count'], 1);
+          assert.isAtLeast(result.releases.length, 1);
         });
 
       });
@@ -304,7 +325,7 @@ describe('MusicBrainz-api', function() {
       describe('searchArea', () => {
 
         it('find area by name', async () => {
-          const result = await mbApi.searchArea('Île-de-France');
+          const result = await mbApi.searchArea({query: 'Île-de-France'});
           assert.isAtLeast(result.count, 1);
           assert.isAtLeast(result.areas.length, 1);
           assert.strictEqual(result.areas[0].id, mbid.area.IleDeFrance);
@@ -316,7 +337,7 @@ describe('MusicBrainz-api', function() {
         const spotifyUrl = 'https://open.spotify.com/album/' + spotify.album.RacineCarree.id;
 
         it('find url by url', async () => {
-          const result = await mbApi.searchUrl({url: spotifyUrl});
+          const result = await mbApi.searchUrl({query: {url: spotifyUrl}});
           assert.isAtLeast(result.count, 1);
           assert.isAtLeast(result.urls.length, 1);
           assert.strictEqual(result.urls[0].resource, spotifyUrl);


### PR DESCRIPTION
Changes:
* More control to use [browse](https://musicbrainz.org/doc/MusicBrainz_API#Browse) [lookup](https://musicbrainz.org/doc/MusicBrainz_API#Lookups) or [query](https://musicbrainz.org/doc/MusicBrainz_API/Search) [lookup](https://musicbrainz.org/doc/MusicBrainz_API/Lookups).
* Put lookup / search arguments in single argument object, for greater flexibility (API change!)
