### PR TITLE
Rename lookup function

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,13 @@ Arguments:
 *   MBID [(MusicBrainz identifier)](https://wiki.musicbrainz.org/MusicBrainz_Identifier)
 
 ```js
-const artist = await mbApi.getEntity('artist', {query: 'ab2528d9-719f-4261-8098-21849222a0f2'});
+const artist = await mbApi.lookupEntity('artist', {query: 'ab2528d9-719f-4261-8098-21849222a0f2'});
 ```
 
 ### Lookup area
 
 ```js
-const area = await mbApi.getArea({query: 'ab2528d9-719f-4261-8098-21849222a0f2'});
+const area = await mbApi.lookupArea({query: 'ab2528d9-719f-4261-8098-21849222a0f2'});
 ```
 
 ### Lookup artist
@@ -108,40 +108,61 @@ const area = await mbApi.getArea({query: 'ab2528d9-719f-4261-8098-21849222a0f2'}
 Lookup an `artist` and include their `releases`, `release-groups` and `aliases`
 
 ```js
-const artist = await mbApi.getArtist({query: 'ab2528d9-719f-4261-8098-21849222a0f2'});
+const artist = await mbApi.lookupArtist({query: 'ab2528d9-719f-4261-8098-21849222a0f2'});
 ```
 
-or use the browse API:
+### Lookup instrument
+
+Lookup an instrument
 
 ```js
-const artist = await mbApi.getArtist({artist: 'ab2528d9-719f-4261-8098-21849222a0f2'});
+const artist = await mbApi.lookupInstrument({query: 'b3eac5f9-7859-4416-ac39-7154e2e8d348'});
+```
+
+### Lookup label
+
+Lookup a label
+
+```js
+const artist = await mbApi.lookupInstrument({query: '25dda9f9-f069-4898-82f0-59330a106c7f'});
+```
+
+### Lookup place
+
+```js
+const artist = await mbApi.lookupPlace({query: 'e6cfb74d-d69b-44c3-b890-1b3f509816e4'});
 ```
 
 The second argument can be used to pass [subqueries](https://wiki.musicbrainz.org/Development/XML_Web_Service/Version_2#Subqueries), which will return more (nested) information:
 ```js
-const artist = await mbApi.getArtist('ab2528d9-719f-4261-8098-21849222a0f2', ['releases', 'recordings', 'url-rels']);
+const artist = await mbApi.lookupArtist('ab2528d9-719f-4261-8098-21849222a0f2', ['releases', 'recordings', 'url-rels']);
 ```
 
 ### Lookup recording
 
 The second argument can be used to pass [subqueries](https://wiki.musicbrainz.org/Development/XML_Web_Service/Version_2#Subqueries):
 ```js
-const artist = await mbApi.getRecording({query: '16afa384-174e-435e-bfa3-5591accda31c'}, ['artists', 'url-rels']);
+const artist = await mbApi.lookupRecording({query: '16afa384-174e-435e-bfa3-5591accda31c'}, ['artists', 'url-rels']);
 ```
 
 ### Lookup release
 ```js
-const release = await mbApi.getRelease({query: '976e0677-a480-4a5e-a177-6a86c1900bbf'}, ['artists', 'url-rels']);
+const release = await mbApi.lookupRelease({query: '976e0677-a480-4a5e-a177-6a86c1900bbf'}, ['artists', 'url-rels']);
 ```
 
 ### Lookup release-group
 ```js
-const releaseGroup = await mbApi.getReleaseGroup({query: '19099ea5-3600-4154-b482-2ec68815883e'});
+const releaseGroup = await mbApi.lookupReleaseGroup({query: '19099ea5-3600-4154-b482-2ec68815883e'});
 ```
 
 ### Lookup work
 ```js
-const work = await mbApi.getWork({query: 'b2aa02f4-6c95-43be-a426-aedb9f9a3805'});
+const work = await mbApi.lookupWork({query: 'b2aa02f4-6c95-43be-a426-aedb9f9a3805'});
+```
+
+### Lookup URL
+```js
+const url = await mbApi.lookupUrl({query: 'c69556a6-7ded-4c54-809c-afb45a1abe7d'});
 ```
 
 ## Search (query)
@@ -251,7 +272,7 @@ const mbid_Formidable = '16afa384-174e-435e-bfa3-5591accda31c';
 const isrc_Formidable = 'BET671300161';
 
     
-const recording = await mbApi.getRecording(mbid_Formidable);
+const recording = await mbApi.lookupRecording(mbid_Formidable);
 
 // Authentication the http-session against MusicBrainz (as defined in config.baseUrl)
 const succeed = await mbApi.login();
@@ -264,7 +285,7 @@ await mbApi.addIsrc(recording, isrc_Formidable);
 ### Submit recording URL
 
 ```js
-const recording = await mbApi.getRecording('16afa384-174e-435e-bfa3-5591accda31c');
+const recording = await mbApi.lookupRecording('16afa384-174e-435e-bfa3-5591accda31c');
 
 const succeed = await mbApi.login();
 assert.isTrue(succeed, 'Login successful');
@@ -277,7 +298,7 @@ await mbApi.addUrlToRecording(recording, {
 
 Actually a Spotify-track-ID can be submitted easier: 
 ```js
-const recording = await mbApi.getRecording('16afa384-174e-435e-bfa3-5591accda31c');
+const recording = await mbApi.lookupRecording('16afa384-174e-435e-bfa3-5591accda31c');
 
 const succeed = await mbApi.login();
 assert.isTrue(succeed, 'Login successful');

--- a/src/musicbrainz-api.ts
+++ b/src/musicbrainz-api.ts
@@ -215,7 +215,7 @@ export class MusicBrainzApi {
    * @param mbid
    * @param inc
    */
-  public getEntity<T>(entity: mb.EntityType, mbid: string, inc: Includes[] = []): Promise<T> {
+  public lookupEntity<T>(entity: mb.EntityType, mbid: string, inc: Includes[] = []): Promise<T> {
     return this.restGet<T>(`/${entity}/${mbid}`, {inc: inc.join(' ')});
   }
 
@@ -224,8 +224,8 @@ export class MusicBrainzApi {
    * @param areaId Area MBID
    * @param inc Sub-queries
    */
-  public getArea(areaId: string, inc: Includes[] = []): Promise<mb.IArea> {
-    return this.getEntity<mb.IArea>('area', areaId, inc);
+  public lookupArea(areaId: string, inc: Includes[] = []): Promise<mb.IArea> {
+    return this.lookupEntity<mb.IArea>('area', areaId, inc);
   }
 
   /**
@@ -233,8 +233,35 @@ export class MusicBrainzApi {
    * @param artistId Artist MBID
    * @param inc Sub-queries
    */
-  public getArtist(artistId: string, inc: Includes[] = []): Promise<mb.IArtist> {
-    return this.getEntity<mb.IArtist>('artist', artistId, inc);
+  public lookupArtist(artistId: string, inc: Includes[] = []): Promise<mb.IArtist> {
+    return this.lookupEntity<mb.IArtist>('artist', artistId, inc);
+  }
+
+  /**
+   * Lookup instrument
+   * @param artistId Instrument MBID
+   * @param inc Sub-queries
+   */
+  public lookupInstrument(instrumentId: string, inc: Includes[] = []): Promise<mb.IInstrument> {
+    return this.lookupEntity<mb.IInstrument>('instrument', instrumentId, inc);
+  }
+
+  /**
+   * Lookup label
+   * @param labelId Area MBID
+   * @param inc Sub-queries
+   */
+  public lookupLabel(labelId: string, inc: Includes[] = []): Promise<mb.ILabel> {
+    return this.lookupEntity<mb.ILabel>('label', labelId, inc);
+  }
+
+  /**
+   * Lookup place
+   * @param placeId Area MBID
+   * @param inc Sub-queries
+   */
+  public lookupPlace(placeId: string, inc: Includes[] = []): Promise<mb.IPlace> {
+    return this.lookupEntity<mb.IPlace>('place', placeId, inc);
   }
 
   /**
@@ -243,8 +270,8 @@ export class MusicBrainzApi {
    * @param inc Include: artist-credits, labels, recordings, release-groups, media, discids, isrcs (with recordings)
    * ToDo: ['recordings', 'artists', 'artist-credits', 'isrcs', 'url-rels', 'release-groups']
    */
-  public getRelease(releaseId: string, inc: Includes[] = []): Promise<mb.IRelease> {
-    return this.getEntity<mb.IRelease>('release', releaseId, inc);
+  public lookupRelease(releaseId: string, inc: Includes[] = []): Promise<mb.IRelease> {
+    return this.lookupEntity<mb.IRelease>('release', releaseId, inc);
   }
 
   /**
@@ -252,24 +279,8 @@ export class MusicBrainzApi {
    * @param releaseGroupId Release-group MBID
    * @param inc Include: ToDo
    */
-  public getReleaseGroup(releaseGroupId: string, inc: Includes[] = []): Promise<mb.IReleaseGroup> {
-    return this.getEntity<mb.IReleaseGroup>('release-group', releaseGroupId, inc);
-  }
-
-  /**
-   * Lookup work
-   * @param workId Work MBID
-   */
-  public getWork(workId: string): Promise<mb.IWork> {
-    return this.getEntity<mb.IWork>('work', workId);
-  }
-
-  /**
-   * Lookup label
-   * @param labelId Label MBID
-   */
-  public getLabel(labelId: string): Promise<mb.ILabel> {
-    return this.getEntity<mb.ILabel>('label', labelId);
+  public lookupReleaseGroup(releaseGroupId: string, inc: Includes[] = []): Promise<mb.IReleaseGroup> {
+    return this.lookupEntity<mb.IReleaseGroup>('release-group', releaseGroupId, inc);
   }
 
   /**
@@ -277,8 +288,24 @@ export class MusicBrainzApi {
    * @param recordingId Label MBID
    * @param inc Include: artist-credits, isrcs
    */
-  public getRecording(recordingId: string, inc: Includes[] = []): Promise<mb.IRecording> {
-    return this.getEntity<mb.IRecording>('recording', recordingId, inc);
+  public lookupRecording(recordingId: string, inc: Includes[] = []): Promise<mb.IRecording> {
+    return this.lookupEntity<mb.IRecording>('recording', recordingId, inc);
+  }
+
+  /**
+   * Lookup work
+   * @param workId Work MBID
+   */
+  public lookupWork(workId: string): Promise<mb.IWork> {
+    return this.lookupEntity<mb.IWork>('work', workId);
+  }
+
+  /**
+   * Lookup URL
+   * @param urlId URL MBID
+   */
+  public lookupUrl(urlId: string): Promise<mb.IUrl> {
+    return this.lookupEntity<mb.IUrl>('url', urlId);
   }
 
   public async postRecording(xmlMetadata: XmlMetadata): Promise<void> {

--- a/src/musicbrainz.types.ts
+++ b/src/musicbrainz.types.ts
@@ -2,37 +2,39 @@ import DateTimeFormat = Intl.DateTimeFormat;
 import { IFormData, Includes } from './musicbrainz-api';
 
 export interface IPeriod {
-  'begin': string,
-  'ended': boolean,
-  'end': string
+  'begin': string;
+  'ended': boolean;
+  'end': string;
 }
 
-export interface IArea {
-  id: string,
-  'iso-3166-1-codes': string[],
-  name: string,
-  'sort-name': string,
-  disambiguation: string
+export interface IEntity {
+  id: string;
 }
 
-export interface IAlias {
-  name: string,
-  'sort-name': string,
-  ended: boolean,
-  'type-id': string,
-  type: string,
-  locale: string,
-  primary: string,
-  begin: string,
-  end: string
+export interface IArea extends IEntity {
+  'iso-3166-1-codes': string[];
+  name: string;
+  'sort-name': string;
+  disambiguation: string;
+}
+
+export interface IAlias extends IEntity {
+  name: string;
+  'sort-name': string;
+  ended: boolean;
+  'type-id': string;
+  type: string;
+  locale: string;
+  primary: string;
+  begin: string;
+  end: string;
 }
 
 export interface IMatch {
   score: number; // ToDo: provide feedback: should be a number
 }
 
-export interface IArtist {
-  id: string;
+export interface IArtist extends IEntity {
   name: string;
   disambiguation: string;
   'sort-name': string;
@@ -62,10 +64,28 @@ export interface IArtistCredit {
   name: string;
 }
 
+export interface IEvent extends IEntity {
+  cancelled: boolean;
+  type: string;
+  'life-span': IPeriod;
+  disambiguation: string;
+  'type-id': string;
+  time: string;
+  setlist: string;
+  name: string;
+}
+
+export interface IInstrument extends IEntity {
+  disambiguation: string;
+  name: string;
+  'type-id': string;
+  type: string;
+  description: string;
+}
+
 export type ReleaseQuality = 'normal';  // ToDo
 
-export interface IRelease {
-  id: string;
+export interface IRelease extends IEntity {
   title: string;
   'text-representation': { 'language': string, 'script': string },
   disambiguation: string;
@@ -93,8 +113,7 @@ export interface IReleaseEvent {
 
 export type MediaFormatType = 'Digital Media'; // ToDo
 
-export interface IRecording {
-  id: string;
+export interface IRecording  extends IEntity {
   video: boolean;
   length: number;
   title: string;
@@ -106,8 +125,7 @@ export interface IRecording {
   aliases?: IAlias[];
 }
 
-export interface ITrack {
-  id: string;
+export interface ITrack extends IEntity{
   position: number;
   recording: IRecording;
   'number': string; // in JSON, this is a string field
@@ -134,8 +152,7 @@ export interface ICoverArtArchive {
   back: boolean;
 }
 
-export interface IReleaseGroup {
-  id: string;
+export interface IReleaseGroup extends IEntity {
   count: number;
   title: string;
   'primary-type': string;
@@ -197,33 +214,30 @@ export interface IRelation {
   begin?: null | object;
   'target-type'?: 'url';
   'type-id': string;
-  url?: IURL;
+  url?: IUrl;
   release?: IRelease;
-}
-
-export interface IURL {
-  id: string;
-  resource: string;
 }
 
 export interface IRelationList {
   relations: IRelation[];
 }
 
-export interface IWork {
-  id: string;
+export interface IWork extends IEntity {
   title: string;
 }
 
-export interface ILabel {
-  id: string;
+export interface ILabel extends IEntity {
   name: string;
 }
 
-export interface IUrl {
+export interface IPlace extends IEntity {
+  name: string;
+}
+
+export interface IUrl extends IEntity {
   id: string,
   resource: string,
-  'relation-list': IRelationList[];
+  'relation-list'?: IRelationList[];
 }
 
 export interface IUrlMatch extends IMatch, IUrl {

--- a/test/test-musicbrainz-api.ts
+++ b/test/test-musicbrainz-api.ts
@@ -53,8 +53,29 @@ describe('MusicBrainz-api', function() {
   this.timeout(20000); // MusicBrainz has a rate limiter
 
   const mbid = {
+    area: {
+      Belgium: '5b8a5ee5-0bb3-34cf-9a75-c27c44e341fc',
+      IleDeFrance: 'd79e4501-8cba-431b-96e7-bb9976f0ae76',
+      Lisbon: '9aee8c1a-c7d5-4713-af71-c022bccf50b4'
+    },
     artist: {
-      Stromae: 'ab2528d9-719f-4261-8098-21849222a0f2'
+      Stromae: 'ab2528d9-719f-4261-8098-21849222a0f2',
+      DeadCombo: '092ae9e2-60bf-4b66-aa33-9e31754d1924'
+    },
+    collection: {
+      Ringtone: 'de4fdfc4-53aa-458a-b463-8761cc7f5af8'
+    },
+    event: {
+      DireStraitsAlchemyLoveOverGold: '6d32c658-151e-45ec-88c4-fb8787524d61'
+    },
+    instrument: {
+      spanishAcousticGuitar: '117dacfc-0ad0-4e90-81a4-a28b4c03929b'
+    },
+    label: {
+      Mosaert: '0550200c-22c1-4c62-b761-ef0b3665262b'
+    },
+    place: {
+      Paradiso: '4efe54e1-41f6-490a-85f5-e1c19b04649c'
     },
     recording: {
       Formidable: '16afa384-174e-435e-bfa3-5591accda31c',
@@ -76,12 +97,8 @@ describe('MusicBrainz-api', function() {
     work: {
       Formidable: 'b2aa02f4-6c95-43be-a426-aedb9f9a3805'
     },
-    area: {
-      Belgium: '5b8a5ee5-0bb3-34cf-9a75-c27c44e341fc',
-      IleDeFrance: 'd79e4501-8cba-431b-96e7-bb9976f0ae76'
-    },
-    label: {
-      Mosaert: '0550200c-22c1-4c62-b761-ef0b3665262b'
+    url: {
+      SpotifyLisboaMulata: 'c69556a6-7ded-4c54-809c-afb45a1abe7d'
     }
   };
 
@@ -116,28 +133,40 @@ describe('MusicBrainz-api', function() {
 
     describe('Lookup', () => {
 
-      it('get area', async () => {
-        const area = await mbApi.getArea(mbid.area.Belgium);
+      it('area', async () => {
+        const area = await mbApi.lookupArea(mbid.area.Belgium);
         assert.strictEqual(area.id, mbid.area.Belgium);
         assert.strictEqual(area.name, 'Belgium');
       });
 
-      it('get artist', async () => {
-        const artist = await mbApi.getArtist(mbid.artist.Stromae);
+      it('artist', async () => {
+        const artist = await mbApi.lookupArtist(mbid.artist.Stromae);
         assert.strictEqual(artist.id, mbid.artist.Stromae);
         assert.strictEqual(artist.name, 'Stromae');
       });
 
-      describe('Release', () => {
+      it('instrument', async () => {
+        const instrument = await mbApi.lookupInstrument(mbid.instrument.spanishAcousticGuitar);
+        assert.strictEqual(instrument.id, mbid.instrument.spanishAcousticGuitar);
+        assert.strictEqual(instrument.type, 'String instrument');
+      });
 
-        it('get release Formidable', async () => {
-          const release = await mbApi.getRelease(mbid.release.Formidable);
+      it('label', async () => {
+        const label = await mbApi.lookupLabel(mbid.label.Mosaert);
+        assert.strictEqual(label.id, mbid.label.Mosaert);
+        assert.strictEqual(label.name, 'Mosaert');
+      });
+
+      describe('release', () => {
+
+        it('release Formidable', async () => {
+          const release = await mbApi.lookupRelease(mbid.release.Formidable);
           assert.strictEqual(release.id, mbid.release.Formidable);
           assert.strictEqual(release.title, 'Formidable');
         });
 
         it('check release Anomalie', async () => {
-          const release = await mbApi.getRelease(mbid.release.Anomalie);
+          const release = await mbApi.lookupRelease(mbid.release.Anomalie);
           assert.strictEqual(release.id, mbid.release.Anomalie);
           assert.strictEqual(release.title, 'Anomalie');
         });
@@ -153,7 +182,7 @@ describe('MusicBrainz-api', function() {
         ].forEach(inc => {
 
           it(`get release, include: '${inc.inc}'`, async () => {
-            const release = await mbApi.getRelease(mbid.release.Formidable, [inc.inc as any]);
+            const release = await mbApi.lookupRelease(mbid.release.Formidable, [inc.inc as any]);
             assert.strictEqual(release.id, mbid.release.Formidable);
             assert.strictEqual(release.title, 'Formidable');
             assert.isDefined(release[inc.key], `Should include '${inc.key}'`);
@@ -162,44 +191,10 @@ describe('MusicBrainz-api', function() {
 
       });
 
-      describe('Release-group', () => {
+      describe('recording', () => {
 
-        it('get release-group', async () => {
-          const releaseGroup = await mbApi.getReleaseGroup(mbid.releaseGroup.Formidable);
-          assert.strictEqual(releaseGroup.id, mbid.releaseGroup.Formidable);
-          assert.strictEqual(releaseGroup.title, 'Formidable');
-        });
-
-        [
-          {inc: 'artist-credits', key: 'artist-credit'}
-        ].forEach(inc => {
-
-          it(`get release-group, include: '${inc.inc}'`, async () => {
-            const group = await mbApi.getReleaseGroup(mbid.releaseGroup.Formidable, [inc.inc as any]);
-            assert.strictEqual(group.id, mbid.releaseGroup.Formidable);
-            assert.strictEqual(group.title, 'Formidable');
-            assert.isDefined(group[inc.key], `Should include '${inc.key}'`);
-          });
-        });
-
-      });
-
-      it('get work', async () => {
-        const work = await mbApi.getWork(mbid.work.Formidable);
-        assert.strictEqual(work.id, mbid.work.Formidable);
-        assert.strictEqual(work.title, 'Formidable');
-      });
-
-      it('get label', async () => {
-        const label = await mbApi.getLabel(mbid.label.Mosaert);
-        assert.strictEqual(label.id, mbid.label.Mosaert);
-        assert.strictEqual(label.name, 'Mosaert');
-      });
-
-      describe('Recording', () => {
-
-        it('get recording', async () => {
-          const recording = await mbApi.getRecording(mbid.recording.Formidable);
+        it('recording', async () => {
+          const recording = await mbApi.lookupRecording(mbid.recording.Formidable);
           assert.strictEqual(recording.id, mbid.recording.Formidable);
           assert.strictEqual(recording.title, 'Formidable');
           assert.isUndefined(recording.isrcs);
@@ -214,22 +209,56 @@ describe('MusicBrainz-api', function() {
           {inc: 'releases', key: 'releases'}
         ].forEach(inc => {
 
-          it(`get recording, include: '${inc.inc}'`, async () => {
-            const recording = await mbApi.getRecording(mbid.recording.Formidable, [inc.inc as any]);
+          it(`recording, include: '${inc.inc}'`, async () => {
+            const recording = await mbApi.lookupRecording(mbid.recording.Formidable, [inc.inc as any]);
             assert.strictEqual(recording.id, mbid.recording.Formidable);
             assert.strictEqual(recording.title, 'Formidable');
             assert.isDefined(recording[inc.key], `Should include '${inc.key}'`);
           });
         });
 
-        it('get extended recording', async () => {
-          const recording = await mbApi.getRecording(mbid.recording.Formidable, ['isrcs', 'artists', 'releases', 'url-rels']);
+        it('extended recording', async () => {
+          const recording = await mbApi.lookupRecording(mbid.recording.Formidable, ['isrcs', 'artists', 'releases', 'url-rels']);
           assert.strictEqual(recording.id, mbid.recording.Formidable);
           assert.strictEqual(recording.title, 'Formidable');
           assert.isDefined(recording.isrcs);
           assert.isDefined(recording['artist-credit']);
           // assert.isDefined(recording.releases);
         });
+      });
+
+      describe('release-group', () => {
+
+        it('release-group', async () => {
+          const releaseGroup = await mbApi.lookupReleaseGroup(mbid.releaseGroup.Formidable);
+          assert.strictEqual(releaseGroup.id, mbid.releaseGroup.Formidable);
+          assert.strictEqual(releaseGroup.title, 'Formidable');
+        });
+
+        [
+          {inc: 'artist-credits', key: 'artist-credit'}
+        ].forEach(inc => {
+
+          it(`get release-group, include: '${inc.inc}'`, async () => {
+            const group = await mbApi.lookupReleaseGroup(mbid.releaseGroup.Formidable, [inc.inc as any]);
+            assert.strictEqual(group.id, mbid.releaseGroup.Formidable);
+            assert.strictEqual(group.title, 'Formidable');
+            assert.isDefined(group[inc.key], `Should include '${inc.key}'`);
+          });
+        });
+
+      });
+
+      it('work', async () => {
+        const work = await mbApi.lookupWork(mbid.work.Formidable);
+        assert.strictEqual(work.id, mbid.work.Formidable);
+        assert.strictEqual(work.title, 'Formidable');
+      });
+
+      it('url', async () => {
+        const url = await mbApi.lookupUrl(mbid.url.SpotifyLisboaMulata);
+        assert.strictEqual(url.id,mbid.url.SpotifyLisboaMulata);
+        assert.strictEqual(url.resource, 'https://open.spotify.com/album/5PCfptvsmuFcxsMt86L6wn');
       });
 
     });
@@ -386,7 +415,7 @@ describe('MusicBrainz-api', function() {
     describe('Recording', () => {
 
       it('add link', async () => {
-        const recording = await mbTestApi.getRecording(mbid.recording.Formidable);
+        const recording = await mbTestApi.lookupRecording(mbid.recording.Formidable);
         assert.strictEqual(recording.id, mbid.recording.Formidable);
         assert.strictEqual(recording.title, 'Formidable');
 
@@ -397,7 +426,7 @@ describe('MusicBrainz-api', function() {
       });
 
       it('add Spotify-ID', async () => {
-        const recording = await mbTestApi.getRecording(mbid.recording.Formidable);
+        const recording = await mbTestApi.lookupRecording(mbid.recording.Formidable);
 
         const editNote = `Unit-test musicbrainz-api (${appUrl}), test augment recording with Spotify URL & ISRC`;
         await mbTestApi.addSpotifyIdToRecording(recording, spotify.track.Formidable.id, editNote);
@@ -407,7 +436,7 @@ describe('MusicBrainz-api', function() {
         // https://test.musicbrainz.org/recording/a75b85bf-63dd-4fe1-8008-d15541b93bac
         const recording_id = 'a75b85bf-63dd-4fe1-8008-d15541b93bac';
 
-        const recording = await mbTestApi.getRecording(recording_id);
+        const recording = await mbTestApi.lookupRecording(recording_id);
         const editNote = `Unit-test musicbrainz-api (${appUrl}), test augment recording with Spotify URL & ISRC`;
         await mbTestApi.addSpotifyIdToRecording(recording, '3ZDO5YINwfoifRQ3ElshPM', editNote);
       });
@@ -417,7 +446,7 @@ describe('MusicBrainz-api', function() {
     describe('ISRC', () => {
 
       it('add ISRC', async () => {
-        const recording = await mbTestApi.getRecording(mbid.recording.Formidable, ['isrcs']);
+        const recording = await mbTestApi.lookupRecording(mbid.recording.Formidable, ['isrcs']);
         assert.strictEqual(recording.id, mbid.recording.Formidable);
         assert.strictEqual(recording.title, 'Formidable');
 


### PR DESCRIPTION
Rename lookup functions

`getArea` to `lookupArea`
`getArtist` to `lookupArtist`
`getRecording` to `getRecording`

Add:
- Lookup instrument
-  Lookup label
-  Lookup place
- Lookup URL