### PR TITLE
Fix `browseReleaseGroups()` typings

### DIFF
--- a/src/musicbrainz.types.ts
+++ b/src/musicbrainz.types.ts
@@ -666,7 +666,7 @@ export interface IBrowseReleasesResult {
 }
 
 export interface IBrowseReleaseGroupsResult {
-  'release-groups': IReleaseGroupsQuery[];
+  'release-groups': IReleaseGroup[];
   'release-group-count': number;
   'release-group-offset': number;
 }


### PR DESCRIPTION
Fix `browseReleaseGroups()` typings

Resolves: Borewit/musicbrainz-api#627