### PR TITLE
Fix gender to be string and not null

### DIFF
--- a/src/musicbrainz.types.ts
+++ b/src/musicbrainz.types.ts
@@ -45,7 +45,7 @@ export interface IArtist extends IEntity {
   ipis?: any[]; // ToDo
   isnis?: string[];
   aliases?: IAlias[];
-  gender?: null;
+  gender?: string;
   type?: string;
   area?: IArea;
   begin_area?: IArea;


### PR DESCRIPTION
Hi, thanks for this great library!
I noticed that artist gender returns a string when calling the API, but it is typed as null.