### PR TITLE
Build to dist folder for publishing as an npm module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 .idea/
 *.iml
+dist/
 test/**/*.js
 test/**/*.map
 test/**/*.d.ts

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+lib/
 test/
 node_modules/
 example/

--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "sourceMap": true,
+    "outDir": "../dist",
+    "sourceMap": false,
     "declaration": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "musicbrainz-api",
   "version": "0.10.3",
   "description": "MusicBrainz API client for reading and submitting metadata",
-  "main": "lib/musicbrainz-api",
-  "types": "lib/musicbrainz-api",
+  "main": "dist/musicbrainz-api.js",
+  "types": "dist/musicbrainz-api.d.ts",
   "author": {
     "name": "Borewit",
     "url": "https://github.com/Borewit"


### PR DESCRIPTION
# Summary
This is a follow up to my comment here https://github.com/Borewit/musicbrainz-api/issues/763#issuecomment-1784177038

There's various ways this could be configured but I opted to go with this simple set of changes just so I could get the idea across and hopefully discuss more with you. These are the steps I took to verify the changes:
1. `npm run compile-lib` - generates a `dist` folder of the usable javascript and their associated types in `.d.ts` files
2. `npm pack` - packs the npm module - the final module looks like:
```
npm notice 📦  musicbrainz-api@0.10.3
npm notice === Tarball Contents === 
npm notice 16.6kB README.md                  
npm notice 760B   dist/digest-auth.d.ts      
npm notice 3.4kB  dist/digest-auth.js        
npm notice 11.1kB dist/musicbrainz-api.d.ts  
npm notice 20.6kB dist/musicbrainz-api.js    
npm notice 15.4kB dist/musicbrainz.types.d.ts
npm notice 873B   dist/musicbrainz.types.js  
npm notice 230B   dist/rate-limiter.d.ts     
npm notice 1.1kB  dist/rate-limiter.js       
npm notice 353B   dist/xml/xml-isrc-list.d.ts
npm notice 587B   dist/xml/xml-isrc-list.js  
npm notice 178B   dist/xml/xml-isrc.d.ts     
npm notice 343B   dist/xml/xml-isrc.js       
npm notice 183B   dist/xml/xml-metadata.d.ts 
npm notice 969B   dist/xml/xml-metadata.js   
npm notice 526B   dist/xml/xml-recording.d.ts
npm notice 518B   dist/xml/xml-recording.js  
npm notice 2.8kB  package.json               
npm notice === Tarball Details === 
npm notice name:          musicbrainz-api                         
npm notice version:       0.10.3                                  
npm notice filename:      musicbrainz-api-0.10.3.tgz              
npm notice package size:  17.3 kB                                 
npm notice unpacked size: 76.6 kB                                 
npm notice shasum:        c77db44a30807d83854089333429a4c9594a0f36
npm notice integrity:     sha512-gZQv6dde8PtRt[...]VLqksX0BiglUA==
npm notice total files:   18
```

# Follow ups
- I disabled source maps for `lib` builds because they don't have a purpose in the npm module that I can tell? I imagine you use them for deving, so that might take some reconfiguring.
- I'm not sure what your process is for publishing to npm so I just made some assumptions 😄 
- If you decide to move forward with this, versioning would take some consideration. Not entirely sure if this would be a breaking change but I suspect it might be.