### PR TITLE
Improve MusicBrainz rate limit handling

### DIFF
--- a/lib/rate-limiter.ts
+++ b/lib/rate-limiter.ts
@@ -11,7 +11,8 @@ export class RateLimiter {
   public queue: number[] = [];
   private readonly period: number;
 
-  public constructor(period: number, private maxCalls: number) {
+  public constructor(private maxCalls: number, period: number) {
+    debug(`Rate limiter initialized with max ${maxCalls} calls in ${period} seconds.`);
     this.period = 1000 * period;
   }
 
@@ -21,6 +22,7 @@ export class RateLimiter {
     while (this.queue.length > 0 && this.queue[0] < t0) {
       this.queue.shift();
     }
+    // debug(`Current rate is  ${this.queue.length} per ${this.period / 1000} sec`);
     if (this.queue.length >= this.maxCalls) {
       const delay = this.queue[0] + this.period - now;
       debug(`Client side rate limiter activated: cool down for ${delay / 1000} s...`);


### PR DESCRIPTION
Change rate limit from 50/60 calls/second to 15/18 calls/second, as this seems to be the point where the 503 starts to kick in.

Use the retry mechanism from `got` in case we do get 503, with maximum of 10 retries.