### PR TITLE
Simplify lookup, browse and search functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,106 +82,14 @@ MusicBrainz API documentation: [XML Web Service/Version 2 Lookups](https://wiki.
 ### Generic lookup function
 
 Arguments:
-*   entity: `'artist'` | `'label'` | `'recording'` | `'release'` | `'release-group'` | `'work'` | `'area'` | `'url'`
+*   entity: `'area'` | `'artist'` | `'collection'` | `'instrument'` | `'label'` | `'place'` | `'release'` | `'release-group'` | `'recording'` | `'series'` | `'work'` | `'url'` | `'event'`
 *   MBID [(MusicBrainz identifier)](https://wiki.musicbrainz.org/MusicBrainz_Identifier)
+*   query
 
 ```js
-const artist = await mbApi.lookupEntity('artist', 'ab2528d9-719f-4261-8098-21849222a0f2');
+const artist = await mbApi.lookup('artist', 'ab2528d9-719f-4261-8098-21849222a0f2');
 ```
 
-### Lookup area
-
-```js
-const area = await mbApi.lookupArea('ab2528d9-719f-4261-8098-21849222a0f2');
-```
-
-### Lookup artist
-
-Lookup an `artist` and include their `releases`, `release-groups` and `aliases`
-
-```js
-const artist = await mbApi.lookupArtist('ab2528d9-719f-4261-8098-21849222a0f2');
-```
-
-### Lookup collection
-
-Lookup an instrument
-
-```js
-const collection = await mbApi.lookupCollection('de4fdfc4-53aa-458a-b463-8761cc7f5af8');
-```
-
-Lookup an event
-
-```js
-const event = await mbApi.lookupEvent('6d32c658-151e-45ec-88c4-fb8787524d61');
-```
-
-### Lookup instrument
-
-Lookup an instrument
-
-```js
-const instrument = await mbApi.lookupInstrument('b3eac5f9-7859-4416-ac39-7154e2e8d348');
-```
-
-### Lookup label
-
-Lookup a label
-
-```js
-const label = await mbApi.lookupLabel('25dda9f9-f069-4898-82f0-59330a106c7f');
-```
-
-### Lookup place
-
-```js
-const place = await mbApi.lookupPlace('e6cfb74d-d69b-44c3-b890-1b3f509816e4');
-```
-
-```js
-const place = await mbApi.lookupSeries('1ae6c9bc-2931-4d75-bee4-3dc53dfd246a');
-```
-
-The second argument can be used to pass [subqueries](https://wiki.musicbrainz.org/Development/XML_Web_Service/Version_2#Subqueries), which will return more (nested) information:
-```js
-const artist = await mbApi.lookupArtist('ab2528d9-719f-4261-8098-21849222a0f2', ['releases', 'recordings', 'url-rels']);
-```
-
-### Lookup recording
-
-The second argument can be used to pass [subqueries](https://wiki.musicbrainz.org/Development/XML_Web_Service/Version_2#Subqueries):
-```js
-const recording = await mbApi.lookupRecording('16afa384-174e-435e-bfa3-5591accda31c', ['artists', 'url-rels']);
-```
-
-### Lookup release
-```js
-const release = await mbApi.lookupRelease('976e0677-a480-4a5e-a177-6a86c1900bbf', ['artists', 'url-rels']);
-```
-
-### Lookup release-group
-```js
-const releaseGroup = await mbApi.lookupReleaseGroup('19099ea5-3600-4154-b482-2ec68815883e');
-```
-
-### Lookup work
-```js
-const work = await mbApi.lookupWork('b2aa02f4-6c95-43be-a426-aedb9f9a3805');
-```
-
-### Lookup URL
-```js
-const url = await mbApi.lookupUrl('c69556a6-7ded-4c54-809c-afb45a1abe7d');
-```
-
-## Browse entities
-
-### Browse area
-
-```js
-const area = await browseAreas(query);
-````
 
 | Query argument        | Query value     | 
 |-----------------------|-----------------|  
@@ -190,7 +98,7 @@ const area = await browseAreas(query);
 ### Browse artist
 
 ```js
-const artist = await browseArtist(query);
+const artists = await browse('artist', query);
 ````
 
 | Query argument        | Query value        | 
@@ -204,7 +112,7 @@ const artist = await browseArtist(query);
 
 ### Browse collection
 ```js
-const artist = await browseCollection(query);
+const collections = await browse('collection', query);
 ````
 
 | Query argument        | Query value        | 
@@ -222,7 +130,7 @@ const artist = await browseCollection(query);
 
 ### Browse events
 ```js
-const events = await browseEvents(query);
+const events = await browse('event', query);
 ````
 
 | Query argument        | Query value     | 
@@ -234,7 +142,7 @@ const events = await browseEvents(query);
 
 ### Browse instruments
 ```js
-const instruments = await browseEvents(query);
+const instruments = await browse('event', query);
 ````
 
 | Query argument        | Query value        | 
@@ -243,7 +151,7 @@ const instruments = await browseEvents(query);
 
 ### Browse labels
 ```js
-const labels = await browseLabels(query);
+const labels = await browse('label', query);
 ````
 
 | Query argument     | Query value     | 
@@ -254,7 +162,7 @@ const labels = await browseLabels(query);
 
 ### Browse places
 ```js
-const places = await browsePlaces(query);
+const places = await browse('place', query);
 ````
 
 | Query argument     | Query value     | 
@@ -264,7 +172,7 @@ const places = await browsePlaces(query);
 
 ### Browse recordings
 ```js
-const recordings = await browseRecordings(query);
+const recordings = await browse('recording', query);
 ````
 
 | Query argument     | Query value     | 
@@ -276,7 +184,7 @@ const recordings = await browseRecordings(query);
 
 ### Browse releases
 ```js
-const places = await browseReleases(query);
+const releases = await browse('release', query);
 ````
 
 | Query argument        | Query value        | 
@@ -294,7 +202,7 @@ const places = await browseReleases(query);
 
 ### Browse release-groups
 ```js
-const places = await browseReleaseGroups(query);
+const releaseGroups = await browse('release-group',query);
 ```
 
 | Query argument     | Query value     | 
@@ -305,7 +213,7 @@ const places = await browseReleaseGroups(query);
 
 ### Browse series
 ```js
-const places = await browseSeries();
+const series = await browse('series');
 ````
 
 | Query argument        | Query value        | 
@@ -323,7 +231,7 @@ const places = await browseSeries();
 
 ### Browse works
 ```js
-const places = await browseWorks();
+const works = await browse('work');
 ````
 
 | Query argument     | Query value     | 
@@ -333,7 +241,7 @@ const places = await browseWorks();
 
 ### Browse urls
 ```js
-const urls = await browseUrls();
+const urls = await browse('url');
 ````
 
 | Query argument     | Query value     | 
@@ -347,9 +255,9 @@ Implements [XML Web Service/Version 2/Search](https://wiki.musicbrainz.org/Devel
 
 There are different search fields depending on the entity.
 
-### Generic search function
+### Search function
 
-Searches can be performed using the generic search function: `query(entity: mb.EntityType, query: string | IFormData, offset?: number, limit?: number)`
+Searches can be performed using the generic search function: `query(entity: mb.EntityType, query: string | IFormData, offset?: number, limit?: number): Promise<entity>`
 
 Arguments:
 *   Entity type, which can be one of:
@@ -392,27 +300,25 @@ Same as previous example, but automatically serialize parameters to search query
  mbApi.search('release', 'barcode: 602537479870');
 ````
 
-### Entity specific search functions
-
-The following entity specific search functions are available:
-```TypeScript
-searchArtist(query: string | IFormData, offset?: number, limit?: number): Promise<mb.IArtistList>
-searchReleaseGroup(query: string | IFormData, offset?: number, limit?: number): Promise<mb.IReleaseGroupList>`
-```
+##### Example: search artist by artist name
 
 Search artist:
 ```js
-const result = await mbApi.searchArtist({query: 'Stromae'});
+const result = await mbApi.search('artist', {query: 'Stromae'});
 ```
+
+##### Example: search release-group by artist name
 
 Search release-group:
 ```js
-const result = await mbApi.searchReleaseGroup({query: 'Racine carrée'});
+const result = await mbApi.search('release-group', {query: 'Racine carrée'});
 ```
+
+##### Example: search release-group by release-group and an artist
 
 Search a combination of a release-group and an artist.
 ```js
-const result = await mbApi.searchReleaseGroup({artist: 'Racine carrée', releasegroup: 'Stromae'});
+const result = await mbApi.search('release-group', {artist: 'Racine carrée', releasegroup: 'Stromae'});
 ```
 
 # Submitting data via XML POST
@@ -439,7 +345,7 @@ For all of the following function you need to use a dedicated bot account.
 
 ## Submitting ISRC via post user form-data
 
-<img width="150" src="http://www.clker.com/cliparts/i/w/L/q/u/1/work-in-progress.svg"/>
+<img width="150" src="http://www.clker.com/cliparts/i/w/L/q/u/1/work-in-progress.svg" alt="Work in progress"/>
 Use with caution, and only on a test server, it may clear existing metadata as side effect.
       
 ```js
@@ -448,7 +354,7 @@ const mbid_Formidable = '16afa384-174e-435e-bfa3-5591accda31c';
 const isrc_Formidable = 'BET671300161';
 
     
-const recording = await mbApi.lookupRecording(mbid_Formidable);
+const recording = await mbApi.lookup('recording', mbid_Formidable);
 
 // Authentication the http-session against MusicBrainz (as defined in config.baseUrl)
 const succeed = await mbApi.login();
@@ -461,7 +367,7 @@ await mbApi.addIsrc(recording, isrc_Formidable);
 ### Submit recording URL
 
 ```js
-const recording = await mbApi.lookupRecording('16afa384-174e-435e-bfa3-5591accda31c');
+const recording = await mbApi.lookup('recording', '16afa384-174e-435e-bfa3-5591accda31c');
 
 const succeed = await mbApi.login();
 assert.isTrue(succeed, 'Login successful');
@@ -474,7 +380,7 @@ await mbApi.addUrlToRecording(recording, {
 
 Actually a Spotify-track-ID can be submitted easier: 
 ```js
-const recording = await mbApi.lookupRecording('16afa384-174e-435e-bfa3-5591accda31c');
+const recording = await mbApi.lookup('recording', '16afa384-174e-435e-bfa3-5591accda31c');
 
 const succeed = await mbApi.login();
 assert.isTrue(succeed, 'Login successful');

--- a/lib/musicbrainz-api.ts
+++ b/lib/musicbrainz-api.ts
@@ -106,7 +106,7 @@ export type RecordingIncludes =
   | 'releases'
   | 'isrcs';
 
-export type ReleasesIncludes =
+export type ReleaseIncludes =
   MiscIncludes
   | SubQueryIncludes
   | RelationsIncludes
@@ -266,254 +266,80 @@ export class MusicBrainzApi {
     return response.body;
   }
 
-  // -----------------------------------------------------------------------------------------------------------------
-  // Lookup functions
-  // -----------------------------------------------------------------------------------------------------------------
-
   /**
-   * Generic lookup function
-   * @param entity
-   * @param mbid
-   * @param inc
+   * Lookup entity
+   * @param entity 'area', 'artist', collection', 'instrument', 'label', 'place', 'release', 'release-group', 'recording', 'series', 'work', 'url' or 'event'
+   * @param mbid Entity MBID
+   * @param inc Query, like: {<entity>: <MBID:}
    */
-  public lookupEntity<T, I extends string = never>(entity: mb.EntityType, mbid: string, inc: I[] = []): Promise<T> {
+  public lookup(entity: 'area', mbid: string, inc?: AreaIncludes[]): Promise<mb.IArea>;
+  public lookup(entity: 'artist', mbid: string, inc?: ArtistIncludes[]): Promise<mb.IArtist>;
+  public lookup(entity: 'collection', mbid: string, inc?: CollectionIncludes[]): Promise<mb.ICollection>;
+  public lookup(entity: 'instrument', mbid: string, inc?: InstrumentIncludes[]): Promise<mb.IInstrument>;
+  public lookup(entity: 'label', mbid: string, inc?: LabelIncludes[]): Promise<mb.ILabel>;
+  public lookup(entity: 'place', mbid: string, inc?: PlaceIncludes[]): Promise<mb.IPlace>;
+  public lookup(entity: 'release', mbid: string, inc?: ReleaseIncludes[]): Promise<mb.IRelease>;
+  public lookup(entity: 'release-group', mbid: string, inc?: ReleaseGroupIncludes[]): Promise<mb.IReleaseGroup>;
+  public lookup(entity: 'recording', mbid: string, inc?: RecordingIncludes[]): Promise<mb.IRecording>;
+  public lookup(entity: 'series', mbid: string, inc?: SeriesIncludes[]): Promise<mb.ISeries>;
+  public lookup(entity: 'work', mbid: string, inc?: WorkIncludes[]): Promise<mb.IWork>;
+  public lookup(entity: 'url', mbid: string, inc?: UrlIncludes[]): Promise<mb.IUrl>;
+  public lookup(entity: 'event', mbid: string, inc?: EventIncludes[]): Promise<mb.IEvent>;
+  public lookup<T, I extends string = never>(entity: mb.EntityType, mbid: string, inc: I[] = []): Promise<T> {
     return this.restGet<T>(`/${entity}/${mbid}`, {inc: inc.join(' ')});
   }
 
   /**
-   * Lookup area
-   * @param areaId Area MBID
-   * @param inc Sub-queries
-   */
-  public lookupArea(areaId: string, inc: AreaIncludes[] = []): Promise<mb.IArea> {
-    return this.lookupEntity<mb.IArea, AreaIncludes>('area', areaId, inc);
-  }
-
-  /**
-   * Lookup artist
-   * @param artistId Artist MBID
-   * @param inc Sub-queries
-   */
-  public lookupArtist(artistId: string, inc: ArtistIncludes[] = []): Promise<mb.IArtist> {
-    return this.lookupEntity<mb.IArtist, ArtistIncludes>('artist', artistId, inc);
-  }
-
-  /**
-   * Lookup collection
-   * @param collectionId Collection MBID
-   * @param inc List of additional information to be included about the entity. Any of the entities directly linked to the entity can be included.
-   */
-  public lookupCollection(collectionId: string, inc: ArtistIncludes[] = []): Promise<mb.ICollection> {
-    return this.lookupEntity<mb.ICollection, ArtistIncludes>('collection', collectionId, inc);
-  }
-
-  /**
-   * Lookup instrument
-   * @param artistId Instrument MBID
-   * @param inc Sub-queries
-   */
-  public lookupInstrument(instrumentId: string, inc: InstrumentIncludes[] = []): Promise<mb.IInstrument> {
-    return this.lookupEntity<mb.IInstrument, InstrumentIncludes>('instrument', instrumentId, inc);
-  }
-
-  /**
-   * Lookup label
-   * @param labelId Area MBID
-   * @param inc Sub-queries
-   */
-  public lookupLabel(labelId: string, inc: LabelIncludes[] = []): Promise<mb.ILabel> {
-    return this.lookupEntity<mb.ILabel, LabelIncludes>('label', labelId, inc);
-  }
-
-  /**
-   * Lookup place
-   * @param placeId Area MBID
-   * @param inc Sub-queries
-   */
-  public lookupPlace(placeId: string, inc: PlaceIncludes[] = []): Promise<mb.IPlace> {
-    return this.lookupEntity<mb.IPlace, PlaceIncludes>('place', placeId, inc);
-  }
-
-  /**
-   * Lookup release
-   * @param releaseId Release MBID
-   * @param inc Include: artist-credits, labels, recordings, release-groups, media, discids, isrcs (with recordings)
-   * ToDo: ['recordings', 'artists', 'artist-credits', 'isrcs', 'url-rels', 'release-groups']
-   */
-  public lookupRelease(releaseId: string, inc: ReleasesIncludes[] = []): Promise<mb.IRelease> {
-    return this.lookupEntity<mb.IRelease, ReleasesIncludes>('release', releaseId, inc);
-  }
-
-  /**
-   * Lookup release-group
-   * @param releaseGroupId Release-group MBID
-   * @param inc Include: ToDo
-   */
-  public lookupReleaseGroup(releaseGroupId: string, inc: ReleaseGroupIncludes[] = []): Promise<mb.IReleaseGroup> {
-    return this.lookupEntity<mb.IReleaseGroup, ReleaseGroupIncludes>('release-group', releaseGroupId, inc);
-  }
-
-  /**
-   * Lookup recording
-   * @param recordingId Label MBID
-   * @param inc Include: artist-credits, isrcs
-   */
-  public lookupRecording(recordingId: string, inc: RecordingIncludes[] = []): Promise<mb.IRecording> {
-    return this.lookupEntity<mb.IRecording, RecordingIncludes>('recording', recordingId, inc);
-  }
-
-  /**
-   * Lookup series
-   * @param seriesId Series MBID
-   */
-  public lookupSeries(seriesId: string): Promise<mb.ISeries> {
-    return this.lookupEntity<mb.ISeries, RecordingIncludes>('series', seriesId);
-  }
-
-  /**
-   * Lookup work
-   * @param workId Work MBID
-   */
-  public lookupWork(workId: string, inc: WorkIncludes[] = []): Promise<mb.IWork> {
-    return this.lookupEntity<mb.IWork, WorkIncludes>('work', workId, inc);
-  }
-
-  /**
-   * Lookup URL
-   * @param urlId URL MBID
-   */
-  public lookupUrl(urlId: string, inc: UrlIncludes[] = []): Promise<mb.IUrl> {
-    return this.lookupEntity<mb.IUrl, UrlIncludes>('url', urlId, inc);
-  }
-
-  /**
-   * Lookup Event
-   * @param eventId Event MBID
-   * @param eventIncludes List of sub-queries to enable
-   */
-  public lookupEvent(eventId: string, eventIncludes: EventIncludes[] = []): Promise<mb.IEvent> {
-    return this.lookupEntity<mb.IEvent, EventIncludes>('event', eventId, eventIncludes);
-  }
-
-  // -----------------------------------------------------------------------------------------------------------------
-  // Browse functions
-  // -----------------------------------------------------------------------------------------------------------------
-  // https://wiki.musicbrainz.org/MusicBrainz_API#Browse
-  // https://wiki.musicbrainz.org/MusicBrainz_API#Linked_entities
-  // For example: http://musicbrainz.org/ws/2/release?label=47e718e1-7ee4-460c-b1cc-1192a841c6e5&offset=12&limit=2
-
-  /**
-   * Generic browse function
+   * Browse entity
+   * https://wiki.musicbrainz.org/MusicBrainz_API#Browse
+   * https://wiki.musicbrainz.org/MusicBrainz_API#Linked_entities
    * https://wiki.musicbrainz.org/Development/JSON_Web_Service#Browse_Requests
+   * For example: http://musicbrainz.org/ws/2/release?label=47e718e1-7ee4-460c-b1cc-1192a841c6e5&offset=12&limit=2
    * @param entity MusicBrainz entity
    * @param query Query, like: {<entity>: <MBID:}
    */
-  public browseEntity<T>(entity: mb.EntityType, query?: { [key: string]: any; }): Promise<T> {
+  public browse(entity: 'area', query?: mb.IBrowseAreasQuery): Promise<mb.IBrowseAreasResult>;
+  public browse(entity: 'artist', query?: mb.IBrowseArtistsQuery): Promise<mb.IBrowseArtistsResult>;
+  public browse(entity: 'collection', query?: mb.IBrowseCollectionsQuery): Promise<mb.IBrowseCollectionsResult> ;
+  public browse(entity: 'event', query?: mb.IBrowseEventsQuery): Promise<mb.IBrowseEventsResult>;
+  public browse(entity: 'label', query?: mb.IBrowseLabelsQuery): Promise<mb.IBrowseLabelsResult>;
+  public browse(entity: 'instrument', query?: mb.IBrowseInstrumentsQuery): Promise<mb.IBrowseInstrumentsResult>;
+  public browse(entity: 'place', query?: mb.IBrowsePlacesQuery): Promise<mb.IBrowsePlacesResult>;
+  public browse(entity: 'recording', query?: mb.IBrowseRecordingsQuery): Promise<mb.IBrowseRecordingsResult>;
+  public browse(entity: 'release', query?: mb.IBrowseReleasesQuery): Promise<mb.IBrowseReleasesResult>;
+  public browse(entity: 'release-group', query?: mb.IBrowseReleaseGroupsQuery): Promise<mb.IBrowseReleaseGroupsResult>;
+  public browse(entity: 'series', query?: mb.IBrowseSeriesQuery): Promise<mb.IBrowseSeriesResult>;
+  public browse(entity: 'url', query?: mb.IBrowseUrlsQuery): Promise<mb.IUrl>;
+  public browse(entity: 'work', query?: mb.IBrowseWorksQuery): Promise<mb.IBrowseWorksResult>;
+  public browse<T>(entity: mb.EntityType, query?: { [key: string]: any; }): Promise<T> {
     return this.restGet<T>(`/${entity}`, query);
   }
 
-  /**
-   * Browse areas
-   * @param query Query, like: {<entity>: <MBID:}
-   */
-  public browseAreas(query?: mb.IBrowseAreasQuery): Promise<mb.IBrowseAreasResult> {
-    return this.browseEntity<mb.IBrowseAreasResult>('area', query);
-  }
+  // -----------------------------------------------------------------------------------------------------------------
+  // Query functions
+  // -----------------------------------------------------------------------------------------------------------------
 
   /**
-   * Browse artists
-   * @param query Query, like: {<entity>: <MBID:}
+   * Search an entity using a search query
+   * @param query e.g.: '" artist: Madonna, track: Like a virgin"' or object with search terms: {artist: Madonna}
+   * @param entity e.g. 'recording'
+   * @param query Arguments
    */
-  public browseArtists(query?: mb.IBrowseArtistsQuery): Promise<mb.IBrowseArtistsResult> {
-    return this.browseEntity<mb.IBrowseArtistsResult>('artist', query);
-  }
-
-  /**
-   * Browse collections
-   * @param query Query, like: {<entity>: <MBID:}
-   */
-  public browseCollections(query?: mb.IBrowseCollectionsQuery): Promise<mb.IBrowseCollectionsResult> {
-    return this.browseEntity<mb.IBrowseCollectionsResult>('collection', query);
-  }
-
-  /**
-   * Browse events
-   * @param query Query, like: {<entity>: <MBID:}
-   */
-  public browseEvents(query?: mb.IBrowseEventsQuery): Promise<mb.IBrowseEventsResult> {
-    return this.browseEntity<mb.IBrowseEventsResult>('event', query);
-  }
-
-  /**
-   * Browse instruments
-   * @param query Query, like: {<entity>: <MBID:}
-   */
-  public browseInstruments(query?: mb.IBrowseInstrumentsQuery): Promise<mb.IBrowseInstrumentsResult> {
-    return this.browseEntity<mb.IBrowseInstrumentsResult>('instrument', query);
-  }
-
-  /**
-   * Browse labels
-   * @param query Query, like: {<entity>: <MBID:}
-   */
-  public browseLabels(query?: mb.IBrowseLabelsQuery): Promise<mb.IBrowseLabelsResult> {
-    return this.browseEntity<mb.IBrowseLabelsResult>('label', query);
-  }
-
-  /**
-   * Browse places
-   * @param query Query, like: {<entity>: <MBID:}
-   */
-  public browsePlaces(query?: mb.IBrowsePlacesQuery): Promise<mb.IBrowsePlacesResult> {
-    return this.browseEntity<mb.IBrowsePlacesResult>('place', query);
-  }
-
-  /**
-   * Browse recordings
-   * @param query Query, like: {<entity>: <MBID:}
-   */
-  public browseRecordings(query?: mb.IBrowseRecordingsQuery): Promise<mb.IBrowseRecordingsResult> {
-    return this.browseEntity<mb.IBrowseRecordingsResult>('recording', query);
-  }
-
-  /**
-   * Browse releases
-   * @param query Query, like: {<entity>: <MBID:}
-   */
-  public browseReleases(query?: mb.IBrowseReleasesQuery): Promise<mb.IBrowseReleasesResult> {
-    return this.browseEntity<mb.IBrowseReleasesResult>('release', query);
-  }
-
-  /**
-   * Browse release-groups
-   * @param query Query, like: {<entity>: <MBID:}
-   */
-  public browseReleaseGroups(query?: mb.IReleaseGroupsQuery): Promise<mb.IBrowseReleaseGroupsResult> {
-    return this.browseEntity<mb.IBrowseReleaseGroupsResult>('release-group', query);
-  }
-
-  /**
-   * Browse series
-   * @param query Query, like: {<entity>: <MBID:}
-   */
-  public browseSeries(query?: mb.IBrowseSeriesQuery): Promise<mb.IBrowseSeriesResult> {
-    return this.browseEntity<mb.IBrowseSeriesResult>('series', query);
-  }
-
-  /**
-   * Browse works
-   * @param query Query, like: {<entity>: <MBID:}
-   */
-  public browseWorks(query?: mb.IBrowseWorksQuery): Promise<mb.IBrowseWorksResult> {
-    return this.browseEntity<mb.IBrowseWorksResult>('work', query);
-  }
-
-  /**
-   * Browse URLs
-   * @param query Query, like: {<entity>: <MBID:}
-   */
-  public browseUrls(query?: mb.IBrowseUrlsQuery): Promise<mb.IUrl> {
-    return this.browseEntity<mb.IUrl>('url', query);
+  public search(entity:'area', query: mb.ISearchQuery<AreaIncludes> & mb.ILinkedEntitiesArea): Promise<mb.IAreaList>;
+  public search(artist:'artist', query: mb.ISearchQuery<ArtistIncludes> & mb.ILinkedEntitiesArea): Promise<mb.IArtistList>;
+  public search(artist:'recording', query: mb.ISearchQuery<AreaIncludes> & mb.ILinkedEntitiesArea): Promise<mb.IRecordingList>;
+  public search(artist:'release', query: mb.ISearchQuery<ReleaseIncludes> & mb.ILinkedEntitiesArea): Promise<mb.IReleaseList>;
+  public search(artist:'release-group', query: mb.ISearchQuery<ReleaseGroupIncludes> & mb.ILinkedEntitiesArea): Promise<mb.IReleaseGroupList>;
+  public search(artist:'url', query: mb.ISearchQuery<UrlIncludes> & mb.ILinkedEntitiesArea): Promise<mb.IUrlList>;
+  public search<T extends mb.ISearchResult, I extends string = never>(entity: mb.EntityType, query: mb.ISearchQuery<I>): Promise<T> {
+    const urlQuery: any = {...query};
+    if (typeof query.query === 'object') {
+      urlQuery.query = makeAndQueryString(query.query);
+    }
+    if (Array.isArray(query.inc)) {
+      urlQuery.inc = urlQuery.inc.join(' ');
+    }
+    return this.restGet<T>('/' + entity + '/', urlQuery);
   }
 
   // ---------------------------------------------------------------------------
@@ -702,26 +528,6 @@ export class MusicBrainzApi {
     }
   }
 
-  // -----------------------------------------------------------------------------------------------------------------
-  // Query functions
-  // -----------------------------------------------------------------------------------------------------------------
-
-  /**
-   * Search an entity using a search query
-   * @param query e.g.: '" artist: Madonna, track: Like a virgin"' or object with search terms: {artist: Madonna}
-   * @param entity e.g. 'recording'
-   * @param query Arguments
-   */
-  public search<T extends mb.ISearchResult, I extends string = never>(entity: mb.EntityType, query: mb.ISearchQuery<I>): Promise<T> {
-    const urlQuery: any = {...query};
-    if (typeof query.query === 'object') {
-      urlQuery.query = makeAndQueryString(query.query);
-    }
-    if (Array.isArray(query.inc)) {
-      urlQuery.inc = urlQuery.inc.join(' ');
-    }
-    return this.restGet<T>('/' + entity + '/', urlQuery);
-  }
 
   // -----------------------------------------------------------------------------------------------------------------
   // Helper functions
@@ -742,26 +548,6 @@ export class MusicBrainzApi {
       linkTypeId: mb.LinkType.stream_for_free,
       text: 'https://open.spotify.com/track/' + spotifyId
     }, editNote);
-  }
-
-  public searchArea(query: mb.ISearchQuery<AreaIncludes> & mb.ILinkedEntitiesArea): Promise<mb.IAreaList> {
-    return this.search<mb.IAreaList, AreaIncludes>('area', query);
-  }
-
-  public searchArtist(query: mb.ISearchQuery<ArtistIncludes> & mb.ILinkedEntitiesArtist): Promise<mb.IArtistList> {
-    return this.search<mb.IArtistList, ArtistIncludes>('artist', query);
-  }
-
-  public searchRelease(query: mb.ISearchQuery<ReleasesIncludes> & mb.ILinkedEntitiesRelease): Promise<mb.IReleaseList> {
-    return this.search<mb.IReleaseList, ReleasesIncludes>('release', query);
-  }
-
-  public searchReleaseGroup(query: mb.ISearchQuery<ReleaseGroupIncludes> & mb.ILinkedEntitiesReleaseGroup): Promise<mb.IReleaseGroupList> {
-    return this.search<mb.IReleaseGroupList, ReleaseGroupIncludes>('release-group', query);
-  }
-
-  public searchUrl(query: mb.ISearchQuery<UrlIncludes> & mb.ILinkedEntitiesUrl): Promise<mb.IUrlList> {
-    return this.search<mb.IUrlList, UrlIncludes>('url', query);
   }
 
   private async getSession(): Promise<ISessionInformation> {

--- a/lib/musicbrainz.types.ts
+++ b/lib/musicbrainz.types.ts
@@ -113,6 +113,7 @@ export interface IRelease extends IEntity {
   relations?: IRelation[];
   'artist-credit'?: IArtistCredit[]; // Include 'artist-credits '
   'release-group'?: IReleaseGroup; // Include: 'release-groups'
+  collections?: ICollection[]
 }
 
 export interface IReleaseEvent {
@@ -175,16 +176,19 @@ export interface IReleaseGroup extends IEntity {
   releases?: IRelease[]; // include 'releases'
 }
 
+export interface IAreaMatch extends IArea, IMatch {
+}
+
 export interface IArtistMatch extends IArtist, IMatch {
+}
+
+export interface IRecordingMatch extends IRecording, IMatch {
 }
 
 export interface IReleaseGroupMatch extends IReleaseGroup, IMatch {
 }
 
 export interface IReleaseMatch extends IRelease, IMatch {
-}
-
-export interface IAreaMatch extends IArea, IMatch {
 }
 
 export interface ISearchResult {
@@ -204,6 +208,11 @@ export interface IAreaList extends ISearchResult {
 export interface IReleaseList extends ISearchResult {
   releases: IReleaseMatch[];
   'release-count': number;
+}
+
+export interface IRecordingList extends ISearchResult {
+  recordings: IRecordingMatch[];
+  'recordings-count': number;
 }
 
 export interface IReleaseGroupList extends ISearchResult {
@@ -348,6 +357,7 @@ export interface ISearchQuery<I extends string> extends IPagination {
    */
   query?: string | IFormData,
   inc?: I[]
+  artist?: string;
 }
 
 /**
@@ -593,7 +603,7 @@ export interface IBrowseReleasesQuery extends IPagination {
 /**
  * Browse release-groups query <entity>: <MBID>
  */
-export interface IReleaseGroupsQuery extends IPagination {
+export interface IBrowseReleaseGroupsQuery extends IPagination {
   artist?: string;
   collection?: string;
   release?: string;
@@ -685,13 +695,13 @@ export interface IBrowseReleaseGroupsResult {
 }
 
 export interface IBrowseSeriesResult {
-  series: IReleaseGroupsQuery[];
+  series: IReleaseGroup[];
   'series-count': number;
   'series-offset': number;
 }
 
 export interface IBrowseWorksResult {
-  works: IReleaseGroupsQuery[];
+  works: IReleaseGroup[];
   'work-count': number;
   'work-offset': number;
 }


### PR DESCRIPTION
Remove specific search function in favor of a single typed function: 

- `mbApi.browseArtist(query)`  with `mbApi.browse('artist', query)` 
- `mbApi.lookupArtist('ab2528d9-719f-4261-8098-21849222a0f2')` with `mbApi.lookup('artist', 'ab2528d9-719f-4261-8098-21849222a0f2')` 
- `mbApi.searchArtist({query: 'Stromae'})`  with `mbApi.search('artist', {query: 'Stromae'})` 

Resolves #822 