### PR TITLE
feat(coverartarchive-api): add getReleaseGroupCovers to complement getReleaseCovers

### DIFF
--- a/lib/coverartarchive-api.ts
+++ b/lib/coverartarchive-api.ts
@@ -60,10 +60,10 @@ export class CoverArtArchiveApi {
 
   /**
    *
-   * @param releaseId MusicBrainz Release Group MBID
+   * @param releaseGroupId MusicBrainz Release Group MBID
    */
-  public async getReleaseCovers(releaseGroupId: string, coverType?: 'front' | 'back'): Promise<ICoverInfo> {
-    const path = ['release-group', releaseId];
+  public async getReleaseGroupCovers(releaseGroupId: string, coverType?: 'front' | 'back'): Promise<ICoverInfo> {
+    const path = ['release-group', releaseGroupId];
     if (coverType) {
       path.push(coverType);
     }
@@ -74,5 +74,4 @@ export class CoverArtArchiveApi {
     }
     return info;
   }
-
 }

--- a/lib/coverartarchive-api.ts
+++ b/lib/coverartarchive-api.ts
@@ -58,4 +58,21 @@ export class CoverArtArchiveApi {
     return info;
   }
 
+  /**
+   *
+   * @param releaseId MusicBrainz Release Group MBID
+   */
+  public async getReleaseCovers(releaseGroupId: string, coverType?: 'front' | 'back'): Promise<ICoverInfo> {
+    const path = ['release-group', releaseId];
+    if (coverType) {
+      path.push(coverType);
+    }
+    const info = await this.getJson('/' + path.join('/')) as ICoverInfo;
+    // Hack to correct http addresses into https
+    if (info.release && info.release.startsWith('http:')) {
+      info.release = 'https' + info.release.substring(4);
+    }
+    return info;
+  }
+
 }


### PR DESCRIPTION
Noticed there was no function to get release _group_ covers for which [there is an available API endpoint.](https://musicbrainz.org/doc/Cover_Art_Archive/API#.2Frelease-group.2F.7Bmbid.7D.2Ffront.5B-.28250.7C500.7C1200.29.5D)

