### PR TITLE
make `IMusicBrainzConfig.baseUrl` optional again

### DIFF
--- a/lib/musicbrainz-api.ts
+++ b/lib/musicbrainz-api.ts
@@ -131,7 +131,7 @@ export interface IMusicBrainzConfig {
     username?: string,
     password?: string
   },
-  baseUrl: string,
+  baseUrl?: string,
 
   appName?: string,
   appVersion?: string,
@@ -193,7 +193,7 @@ export class MusicBrainzApi {
     Object.assign(this.config, _config);
 
     this.httpClient = new HttpClient({
-      baseUrl: this.config.baseUrl,
+      baseUrl: this.config.baseUrl as string,
       timeout: 20 * 1000,
       userAgent: `${this.config.appName}/${this.config.appVersion} ( ${this.config.appContactInfo} )`
     });


### PR DESCRIPTION
Hi,
the change to make the `baseUrl` required could break builds and is not mentioned in the docs.
As far as I can see, it still can be optional and we might need to cast the `baseUrl` for the httpClient to a string again.

https://github.com/Borewit/musicbrainz-api/blob/52d05f9c2e7c5487db59547f72da0386336f58f3/lib/musicbrainz-api.ts#L129-L137