### PR TITLE
Workaround for Cover Art Archive API returning HTML instead of JSON

### DIFF
--- a/lib/coverartarchive-api.ts
+++ b/lib/coverartarchive-api.ts
@@ -39,7 +39,7 @@ export class CoverArtArchiveApi {
     });
 
     const contentType = response.headers.get("Content-Type");
-    if (contentType?.toLowerCase() !== "application/json" && response.status === 404) {
+    if (response.status === 404 && contentType?.toLowerCase() !== "application/json") {
       return {
         "error": "Not Found",
         "help": "For usage, please see: https://musicbrainz.org/development/mmd"

--- a/lib/coverartarchive-api.ts
+++ b/lib/coverartarchive-api.ts
@@ -38,7 +38,8 @@ export class CoverArtArchiveApi {
       }
     });
 
-    if (response.status === 404) {
+    const contentType = response.headers.get("Content-Type");
+    if (contentType?.toLowerCase() !== "application/json" && response.status === 404) {
       return {
         "error": "Not Found",
         "help": "For usage, please see: https://musicbrainz.org/development/mmd"

--- a/lib/coverartarchive-api.ts
+++ b/lib/coverartarchive-api.ts
@@ -37,7 +37,23 @@ export class CoverArtArchiveApi {
         Accept: "application/json"
       }
     });
-    return response.json();
+
+    try {
+      const j = await response.json();
+      return j;
+    } catch (e) {
+      if (response.status === 404) {
+        return {
+            "error": "Not Found",
+            "help": "For usage, please see: https://musicbrainz.org/development/mmd"
+        }
+      } else {
+        return {
+          "error": (e as Error).message,
+          "help": "For usage, please see: https://musicbrainz.org/development/mmd"
+        }
+      }
+    }
   }
 
   /**

--- a/lib/coverartarchive-api.ts
+++ b/lib/coverartarchive-api.ts
@@ -38,22 +38,14 @@ export class CoverArtArchiveApi {
       }
     });
 
-    try {
-      const j = await response.json();
-      return j;
-    } catch (e) {
-      if (response.status === 404) {
-        return {
-            "error": "Not Found",
-            "help": "For usage, please see: https://musicbrainz.org/development/mmd"
-        }
-      } else {
-        return {
-          "error": (e as Error).message,
-          "help": "For usage, please see: https://musicbrainz.org/development/mmd"
-        }
+    if (response.status === 404) {
+      return {
+        "error": "Not Found",
+        "help": "For usage, please see: https://musicbrainz.org/development/mmd"
       }
     }
+
+    return response.json();
   }
 
   /**

--- a/test/test-musicbrainz-api.ts
+++ b/test/test-musicbrainz-api.ts
@@ -992,6 +992,28 @@ describe('Cover Art Archive API', function() {
     assert.ok(releaseCoverInfo.images.length > 0, 'releaseCoverInfo.images.length > 0');
   });
 
+  it('Test an ID that does not exist', async () => {
+    const coverArtArchiveApiClient = new CoverArtArchiveApi();
+    const releaseCoverInfo = await coverArtArchiveApiClient.getReleaseGroupCovers('a8d5bd1b-e325-462d-af75-13ff94353101');
+    assert.isDefined(releaseCoverInfo);
+    // @ts-expect-error 
+    assert.isDefined(releaseCoverInfo.error);
+
+  });
+
+  it('Failure test for the content type of the api', async () => {
+    const response = await fetch('https://coverartarchive.org/release/a8d5bd1b-e325-462d-af75-13ff94353101',{
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        UserAgent: "Node.js musicbrains-api"
+      }
+    });
+    const body = await response.text();
+    assert.notEqual(response.headers.get("Content-Type"), "application/json");
+    assert.throws(() => JSON.parse(body), SyntaxError, undefined, 'The cover art api previously returned HTML instead of JSON')
+  });
+
 });
 
 describe.skip('Node specific API', function (){


### PR DESCRIPTION
This should better handle the problem of getting html instead of json when requesting a cover art that does not exist.

It now returns:
```json
{
    "error": "Not Found",
    "help": "For usage, please see: https://musicbrainz.org/development/mmd"
}
```

Closes #1024 