### PR TITLE
Add require-esm compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,27 +473,35 @@ async function getCoverArt(releaseGroupMbid, coverType = '') {
 
 ## CommonJS backward compatibility
 
-For legacy CommonJS projects needing to load the `music-metadata` ESM module, you can use the `loadMusicMetadata` function:
+I recommend CommonJS projects to consider upgrading their project to ECMAScript Module (ESM).
+Please continue reading how to use **musicbrainz-api** in a CommonJS project.
+
+Using Node.js ≥ 22, which is support loading ESM module via require, you can use:
 ```js
-const { loadMusicBrainzApi } = require('musicbrainz-api');
-
-(async () => {
-
-    // Dynamically loads the ESM module in a CommonJS project
-    const  {MusicBrainzApi} = await loadMusicBrainzApi();
-
-    const mbApi = new MusicBrainzApi({
-        appName: 'my-app',
-        appVersion: '0.1.0',
-        appContactInfo: 'user@mail.org',
-    });
-
-    const releaseList = await mbApi.search('release', {query: {barcode: 602537479870}});
-    for(const release of releaseList.releases) {
-        console.log(release.title);
-    }
-})();
+const { MusicBrainzApi } = require('musicbrainz-api');
 ```
 
-> [!NOTE]
-> The `loadMusicMetadata` function is experimental.
+Other CommonJS projects have to use [dynamic import](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/import) to load the **musicbrainz-api** pure ESM module:
+```js
+async function run() {
+  // Dynamically loads the ESM module in a CommonJS project  
+  const { MusicBrainzApi } = await import('musicbrainz-api');
+};
+
+run();
+```
+
+This is known not to work in TypeScript CommonJS projects, as the TypeScript compiler, in my opinion,
+incorrectly converts the [dynamic import](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/import) 
+to `require()`. To perform the dynamic import in TypeScript, you can use [load-esm](https://github.com/Borewit/load-esm):
+
+```js
+import {loadEsm} from 'load-esm';
+
+async function run() {
+    // Dynamically loads the ESM module in a TypeScript CommonJS project  
+  const { MusicBrainzApi } = await loadEsm<typeof import('musicbrainz-api')>('musicbrainz-api');
+};
+
+run();
+```

--- a/lib/entry-default.cjs
+++ b/lib/entry-default.cjs
@@ -1,5 +1,0 @@
-// CommonJS entry point
-"use strict";
-module.exports = {
-  loadMusicBrainzApi: () => import('./entry-default.js'),
-};

--- a/lib/entry-default.ts
+++ b/lib/entry-default.ts
@@ -1,7 +1,2 @@
 export * from './coverartarchive-api.js';
 export * from './musicbrainz-api.js';
-
-/**
- * CommonJS (only) function to load `musicbrainz-api` ESM module
- */
-export declare function loadMusicBrainzApi(): Promise<typeof import('musicbrainz-api')>;

--- a/lib/entry-node.cjs
+++ b/lib/entry-node.cjs
@@ -1,5 +1,0 @@
-// Node.js CommonJS entry point
-"use strict";
-module.exports = {
-    loadMusicBrainzApi: () => import('./entry-node.js'),
-};

--- a/package.json
+++ b/package.json
@@ -4,20 +4,18 @@
   "description": "MusicBrainz API client for reading and submitting metadata",
   "exports": {
     "node": {
-      "import": "./lib/entry-node.js",
-      "require": "./lib/entry-node.cjs"
+      "types": "./lib/entry-node.d.ts",
+      "default": "./lib/entry-node.js"
     },
     "default": {
-      "import": "./lib/entry-default.js",
-      "require": "./lib/entry-default.cjs"
+      "types": "./lib/entry-default.d.ts",
+      "default": "./lib/entry-default.js"
     }
   },
-  "types": "lib/index.d.ts",
+  "types": "lib/entry-default.d.ts",
   "files": [
     "lib/**/*.js",
-    "lib/**/*.d.ts",
-    "lib/entry-node.cjs",
-    "lib/entry-default.cjs"
+    "lib/**/*.d.ts"
   ],
   "type": "module",
   "author": {


### PR DESCRIPTION
Changes:
1. Add require-esm compatibility: allow Node.js ≥ 22 to load this module using `require('musicbrainz-api')
2. Replace `loadMusicBrainzApi()` with `load-esm`