### PR TITLE
Fix fetch front or back cover

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,26 +425,40 @@ await mbApi.addSpotifyIdToRecording(recording, '2AMysGXOe0zzZJMtH3Nizb');
 This library also supports the [Cover Art Archive API](https://musicbrainz.org/doc/Cover_Art_Archive/API).
 
 ### Fetch Release Cover Art
+
+#### Fetch available cover art information
+
 ```js
 import { CoverArtArchiveApi } from 'musicbrainz-api';
 
 const coverArtArchiveApiClient = new CoverArtArchiveApi();
 
-async function getReleaseCoverArt(releaseMbid, coverType = '') {
-    try {
-        const coverInfo = await coverArtArchiveApiClient.getReleaseCovers(releaseMbid, coverType);
-        console.log(`Cover info for ${coverType || 'all covers'}`, coverInfo);
-    } catch (error) {
-        console.error(`Failed to fetch ${coverType || 'all covers'}:`, error);
+async function fetchCoverArt(releaseMbid, coverType = '') {
+    const coverInfo = await coverArtArchiveApiClient.getReleaseCovers(releaseMbid);
+    for(const image of coverInfo.images) {
+        console.log(`Cover art front=${image.front} back=${image.back} url=${image.image}`);
     }
 }
 
-(async () => {
-    const releaseMbid = 'your-release-mbid-here';  // Replace with actual MBID
-    await getReleaseCoverArt(releaseMbid); // Get all covers
-    await getReleaseCoverArt(releaseMbid, 'front'); // Get best front cover
-    await getReleaseCoverArt(releaseMbid, 'back'); // Get best back cover
-})();
+fetchCoverArt('976e0677-a480-4a5e-a177-6a86c1900bbf').catch(error => {
+    console.error(`Failed to fetch cover art: ${error.message}`);
+})
+```
+
+#### Fetch front or back cover for a release
+```js
+import { CoverArtArchiveApi } from 'musicbrainz-api';
+
+const coverArtArchiveApiClient = new CoverArtArchiveApi();
+
+async function fetchCoverArt(releaseMbid, coverType = '') {
+    const coverInfo = await coverArtArchiveApiClient.getReleaseCover(releaseMbid, 'front');
+    console.log(`Cover art url=${coverInfo.url}`);
+}
+
+fetchCoverArt('976e0677-a480-4a5e-a177-6a86c1900bbf').catch(error => {
+    console.error(`Failed to fetch cover art: ${error.message}`);
+})
 ```
 
 ### Release Group Cover Art
@@ -453,22 +467,32 @@ import { CoverArtArchiveApi } from 'musicbrainz-api';
 
 const coverArtArchiveApiClient = new CoverArtArchiveApi();
 
-async function getCoverArt(releaseGroupMbid, coverType = '') {
-    try {
-        const coverInfo = await coverArtArchiveApiClient.getReleaseGroupCovers(releaseGroupMbid, coverType);
-        console.log(`Cover info for ${coverType || 'all covers'}`, coverInfo);
-    } catch (error) {
-        console.error(`Failed to fetch ${coverType || 'all covers'}:`, error);
+async function fetchCoverArt(releaseMbid, coverType = '') {
+    const coverInfo = await coverArtArchiveApiClient.getReleaseGroupCovers(releaseMbid);
+    for(const image of coverInfo.images) {
+        console.log(`Cover art front=${image.front} back=${image.back} url=${image.image}`);
     }
 }
 
-(async () => {
-    const releaseGroupMbid = 'your-release-group-mbid-here';  // Replace with actual MBID
-    await getCoverArt(releaseGroupMbid); // Get all covers
-    await getCoverArt(releaseGroupMbid, 'front'); // Get best front cover
-    await getCoverArt(releaseGroupMbid, 'back'); // Get best back cover
-})();
+fetchCoverArt('976e0677-a480-4a5e-a177-6a86c1900bbf').catch(error => {
+    console.error(`Failed to fetch cover art: ${error.message}`);
+})
+```
 
+#### Fetch front or back cover for a release-group
+```js
+import { CoverArtArchiveApi } from 'musicbrainz-api';
+
+const coverArtArchiveApiClient = new CoverArtArchiveApi();
+
+async function fetchCoverArt(releaseMbid, coverType = '') {
+    const coverInfo = await coverArtArchiveApiClient.getReleaseGroupCover(releaseMbid, 'front');
+    console.log(`Cover art url=${coverInfo.url}`);
+}
+
+fetchCoverArt('976e0677-a480-4a5e-a177-6a86c1900bbf').catch(error => {
+    console.error(`Failed to fetch cover art: ${error.message}`);
+})
 ```
 
 ## CommonJS backward compatibility

--- a/lib/coverartarchive-api.ts
+++ b/lib/coverartarchive-api.ts
@@ -22,14 +22,20 @@ export interface IImage {
   }
 }
 
-export interface ICoverInfo {
+export type CoverType = 'front' | 'back';
+
+export interface ICoversInfo {
   images: IImage[];
   release: string;
 }
 
+export interface ICoverInfo {
+  url: string | null;
+}
+
 export class CoverArtArchiveApi {
 
-  private httpClient = new HttpClient({baseUrl: 'https://coverartarchive.org', userAgent: 'Node.js musicbrains-api', timeout: 20000})
+  private httpClient = new HttpClient({baseUrl: 'https://coverartarchive.org', userAgent: 'Node.js musicbrains-api', timeout: 20000, followRedirects: false});
 
   private async getJson(path: string) {
     const response = await this.httpClient.get(path, {
@@ -49,24 +55,71 @@ export class CoverArtArchiveApi {
     return response.json();
   }
 
+  private async getCoverRedirect(path: string): Promise<string|null> {
+    const response = await this.httpClient.get(path, {
+      followRedirects: false
+    });
+    switch(response.status) {
+      case 307:
+        return response.headers.get('LOCATION') as string;
+      case 400:
+        throw new Error('Invalid UUID');
+      case 404:
+        // No release with this MBID
+        return null;
+      case 405:
+        throw new Error('Invalid HTTP method');
+      case 503:
+        return null;
+      default:
+        throw new Error(`Unexpected HTTP-status response: ${response.status}`);
+    }
+  }
+
   /**
    * Fetch release
    * @releaseId Release MBID
    * @param releaseId MusicBrainz Release MBID
-   * @param coverType Cover type
    */
-  public getReleaseCovers(releaseId: string, coverType?: 'front' | 'back'): Promise<ICoverInfo> {
-    return this.getCovers(releaseId, 'release', coverType);
+  public getReleaseCovers(releaseId: string): Promise<ICoversInfo> {
+    return this.getCovers(releaseId, 'release');
   }
 
   /**
    * Fetch release-group
    * @releaseGroupId Release-group MBID
    * @param releaseGroupId MusicBrainz Release Group MBID
-   * @param coverType Cover type
    */
-  public getReleaseGroupCovers(releaseGroupId: string, coverType?: 'front' | 'back'): Promise<ICoverInfo> {
-    return this.getCovers(releaseGroupId, 'release-group', coverType);
+  public getReleaseGroupCovers(releaseGroupId: string): Promise<ICoversInfo> {
+    return this.getCovers(releaseGroupId, 'release-group');
+  }
+
+  /**
+   * Fetch release cover
+   * @releaseId Release MBID
+   * @param releaseId MusicBrainz Release MBID
+   * @param coverType Front or back cover
+   */
+  public getReleaseCover(releaseId: string, coverType: CoverType): Promise<ICoverInfo> {
+    return this.getCover(releaseId, 'release', coverType);
+  }
+
+  /**
+   * Fetch release-group cover
+   * @releaseId Release-group MBID
+   * @param releaseGroupId MusicBrainz Release-group MBID
+   * @param coverType Front or back cover
+   */
+  public getReleaseGroupCover(releaseGroupId: string, coverType: CoverType): Promise<ICoverInfo> {
+    return this.getCover(releaseGroupId, 'release-group', coverType);
+  }
+
+  private static makePath(releaseId: string, releaseType: 'release' | 'release-group' = 'release', coverType?: CoverType): string {
+    const path = [releaseType, releaseId];
+    if (coverType) {
+      path.push(coverType);
+    }
+    return`/${path.join('/')}`;
   }
 
   /**
@@ -76,17 +129,25 @@ export class CoverArtArchiveApi {
    * @param releaseType Fetch covers for specific release or release-group
    * @param coverType Cover type
    */
-  private async getCovers(releaseId: string, releaseType: 'release' | 'release-group' = 'release', coverType?: 'front' | 'back'): Promise<ICoverInfo> {
-    const path = [releaseType, releaseId];
-    if (coverType) {
-      path.push(coverType);
-    }
-    const info = await this.getJson(`/${path.join('/')}`) as ICoverInfo;
+  private async getCovers(releaseId: string, releaseType: 'release' | 'release-group' = 'release'): Promise<ICoversInfo> {
+    const info = await this.getJson(CoverArtArchiveApi.makePath(releaseId, releaseType)) as ICoversInfo;
     // Hack to correct http addresses into https
     if (info.release?.startsWith('http:')) {
       info.release = `https${info.release.substring(4)}`;
     }
     return info;
+  }
+
+  /**
+   * Fetch covers
+   * @releaseId MBID
+   * @param releaseId MusicBrainz Release Group MBID
+   * @param releaseType Fetch covers for specific release or release-group
+   * @param coverType Cover type
+   */
+  private async getCover(releaseId: string, releaseType: 'release' | 'release-group' = 'release', coverType?: CoverType): Promise<ICoverInfo> {
+    const url= await this.getCoverRedirect(CoverArtArchiveApi.makePath(releaseId, releaseType, coverType));
+    return {url: url};
   }
 
 }

--- a/lib/http-client.ts
+++ b/lib/http-client.ts
@@ -6,6 +6,7 @@ export interface IHttpClientOptions {
   baseUrl: string,
   timeout: number;
   userAgent: string;
+  followRedirects?: boolean;
 }
 
 export interface IFetchOptions {
@@ -44,7 +45,7 @@ export class HttpClient {
 
     if (!options) options = {};
 
-    let url = `${this.options.baseUrl}/${path}`;
+    let url = path.startsWith('/') ? `${this.options.baseUrl}${path}` : `${this.options.baseUrl}/${path}`;
     if (options.query) {
         url += `?${new URLSearchParams(options.query)}`;
     }

--- a/lib/musicbrainz-api.ts
+++ b/lib/musicbrainz-api.ts
@@ -218,7 +218,7 @@ export class MusicBrainzApi {
 
     await this.applyRateLimiter();
 
-    const response = await this.httpClient.get(`ws/2${relUrl}`, {
+    const response = await this.httpClient.get(`/ws/2${relUrl}`, {
       query,
       retryLimit: 10
     });
@@ -315,7 +315,7 @@ export class MusicBrainzApi {
 
     const clientId = `${this.config.appName.replace(/-/g, '.')}-${this.config.appVersion}`;
 
-    const path = `ws/2/${entity}/`;
+    const path = `/ws/2/${entity}/`;
     // Get digest challenge
 
     let digest = '';
@@ -363,7 +363,7 @@ export class MusicBrainzApi {
     formData.password = this.config.botAccount?.password;
     formData.remember_me = 1;
 
-    const response = await this.httpClient.postForm(`${entity}/${mbid}/edit`, formData, {
+    const response = await this.httpClient.postForm(`/${entity}/${mbid}/edit`, formData, {
       followRedirects: false
     });
     if (response.status === HttpStatus.OK)

--- a/test/test-musicbrainz-api.ts
+++ b/test/test-musicbrainz-api.ts
@@ -749,7 +749,7 @@ describe('MusicBrainz-api', function () {
         const result = await mbApi.search('release-group', {query});
         assert.isAtLeast(result.count, 1);
         const releaseGroup = result["release-groups"][0];
-        assert.strictEqual(releaseGroup.count, 2);
+        assert.isNumber(releaseGroup.count, 'releaseGroup.count');
         assert.strictEqual(releaseGroup.score, 100);
       });
 
@@ -1074,36 +1074,41 @@ describe('Cover Art Archive API', function() {
 
   it('Get all cover-art for release Formidable', async () => {
     const coverArtArchiveApiClient = new CoverArtArchiveApi();
-    const releaseCoverInfo = await coverArtArchiveApiClient.getReleaseCovers(mbid.release.Formidable);
-    assert.isDefined(releaseCoverInfo);
-    assert.strictEqual(releaseCoverInfo.release, releaseMusicBrainzBaseUrl + mbid.release.Formidable, 'releaseCoverInfo.release');
-    assert.isDefined(releaseCoverInfo.images, 'releaseCoverInfo.images');
-    assert.ok(releaseCoverInfo.images.length > 0, 'releaseCoverInfo.images.length > 0');
+    const releaseCoversInfo = await coverArtArchiveApiClient.getReleaseCovers(mbid.release.Formidable);
+    assert.isDefined(releaseCoversInfo);
+    assert.strictEqual(releaseCoversInfo.release, releaseMusicBrainzBaseUrl + mbid.release.Formidable, 'releaseCoversInfo.release');
+    assert.isDefined(releaseCoversInfo.images, 'releaseCoversInfo.images');
+    assert.ok(releaseCoversInfo.images.length > 0, 'releaseCoversInfo.images.length > 0');
   });
 
-  it('Get best back cover for release Dire Straits', async () => {
+  it('Get the back cover for release Dire Straits', async () => {
     const coverArtArchiveApiClient = new CoverArtArchiveApi();
-    const releaseCoverInfo = await coverArtArchiveApiClient.getReleaseCovers(mbid.release.DireStraits);
+    const releaseCoverInfo = await coverArtArchiveApiClient.getReleaseCover(mbid.release.DireStraits, 'back');
     assert.isDefined(releaseCoverInfo);
-    assert.strictEqual(releaseCoverInfo.release, releaseMusicBrainzBaseUrl + mbid.release.DireStraits, 'releaseCoverInfo.release');
-    assert.isDefined(releaseCoverInfo.images, 'releaseCoverInfo.images');
-    assert.ok(releaseCoverInfo.images.length > 0, 'releaseCoverInfo.images.length > 0');
+    expect(releaseCoverInfo.url).to.be.a('string').and.to.match(/^https/);
   });
 
-  it('Get front cover for release group Formidable', async () => {
+  it('Get cover information for release group Formidable', async () => {
     const coverArtArchiveApiClient = new CoverArtArchiveApi();
-    const releaseCoverInfo = await coverArtArchiveApiClient.getReleaseGroupCovers(mbid.releaseGroup.Formidable);
+    const releaseCoversInfo = await coverArtArchiveApiClient.getReleaseGroupCovers(mbid.releaseGroup.Formidable);
+    assert.isDefined(releaseCoversInfo);
+    assert.isDefined(releaseCoversInfo.images, 'releaseCoversInfo.images');
+    assert.ok(releaseCoversInfo.images.length > 0, 'releaseCoversInfo.images.length > 0');
+  });
+
+  it('Get the front cover for release group Formidable', async () => {
+    const coverArtArchiveApiClient = new CoverArtArchiveApi();
+    const releaseCoverInfo = await coverArtArchiveApiClient.getReleaseGroupCover(mbid.releaseGroup.Formidable, 'front');
     assert.isDefined(releaseCoverInfo);
-    assert.isDefined(releaseCoverInfo.images, 'releaseCoverInfo.images');
-    assert.ok(releaseCoverInfo.images.length > 0, 'releaseCoverInfo.images.length > 0');
+    expect(releaseCoverInfo.url).to.be.a('string').and.to.match(/^https/);
   });
 
   it('Test an ID that does not exist', async () => {
     const coverArtArchiveApiClient = new CoverArtArchiveApi();
-    const releaseCoverInfo = await coverArtArchiveApiClient.getReleaseGroupCovers('a8d5bd1b-e325-462d-af75-13ff94353101');
-    assert.isDefined(releaseCoverInfo);
+    const releaseCoversInfo = await coverArtArchiveApiClient.getReleaseGroupCovers('a8d5bd1b-e325-462d-af75-13ff94353101');
+    assert.isDefined(releaseCoversInfo);
     // @ts-expect-error 
-    assert.isDefined(releaseCoverInfo.error);
+    assert.isDefined(releaseCoversInfo.error);
 
   });
 


### PR DESCRIPTION
Breaking API Changes:

Replaces:
```ts
public getReleaseCovers(releaseGroupId: string, coverType?: 'front' | 'back'): Promise<ICoversInfo>;
public getReleaseGroupCovers(releaseGroupId: string, coverType?: 'front' | 'back'): Promise<ICoversInfo>;
```
with:
```ts
public getReleaseCovers(releaseGroupId: string): Promise<ICoversInfo>;
public getReleaseGroupCovers(releaseGroupId: string): Promise<ICoversInfo>;

public getReleaseCover(releaseId: string, coverType: CoverType): Promise<ICoverInfo>
public getReleaseGroupCover(releaseId: string, coverType: CoverType): Promise<ICoverInfo>
```


Resolves #1024