### PR TITLE
Add support for lookup of multiple URL's

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,27 @@ Arguments:
 - MBID (`string`): [(MusicBrainz identifier)](https://wiki.musicbrainz.org/MusicBrainz_Identifier)
 - include arguments (`string[]`), see [Include arguments](#include-arguments)
 
+#### Lookup URLs
+
+There is special method to lookup URL entity / entities by one, or an array of URLs 
+([MusicBrainz documentation](https://musicbrainz.org/doc/MusicBrainz_API#url_(by_text))):
+
+```js
+const urls = await mbApi.lookupUrl(['https://open.spotify.com/track/2AMysGXOe0zzZJMtH3Nizb', 'https://open.spotify.com/track/78Teboqh9lPIxWlIW5RMQL']);
+```
+
+or 
+
+```js
+const url = await mbApi.lookupUrl('https://open.spotify.com/track/2AMysGXOe0zzZJMtH3Nizb']);
+```
+
+Arguments:
+- url (`string` | `string[]`): URL or array of URLs
+- include arguments (`string[]`), see [Include arguments](#include-arguments)
+
+Note that the return type is different, depending on if a single URL or an array of URLs is provided.
+
 ### Browse artist
 
 ```js

--- a/lib/http-client.ts
+++ b/lib/http-client.ts
@@ -2,6 +2,11 @@ import type {Cookie} from "tough-cookie";
 
 export type HttpFormData = { [key: string]: string; }
 
+/**
+ * Allows multiple entries for the same key
+ */
+export type MultiQueryFormData = { [key: string]: string | string[]; }
+
 export interface IHttpClientOptions {
   baseUrl: string,
   timeout: number;
@@ -10,7 +15,7 @@ export interface IHttpClientOptions {
 }
 
 export interface IFetchOptions {
-    query?: HttpFormData;
+    query?: MultiQueryFormData;
     retryLimit?: number;
     body?: string;
     headers?: HeadersInit;
@@ -47,7 +52,14 @@ export class HttpClient {
 
     let url = path.startsWith('/') ? `${this.options.baseUrl}${path}` : `${this.options.baseUrl}/${path}`;
     if (options.query) {
-        url += `?${new URLSearchParams(options.query)}`;
+      const urlSearchParams = new URLSearchParams();
+      for(const key of Object.keys(options.query)) {
+        const value = options.query[key];
+        (Array.isArray(value) ? value : [value]).forEach(value => {
+          urlSearchParams.append(key, value);
+        })
+      }
+      url += `?${urlSearchParams.toString()}`;
     }
 
     const cookies = await this.getCookies();

--- a/lib/musicbrainz.types.ts
+++ b/lib/musicbrainz.types.ts
@@ -329,14 +329,14 @@ export interface ISeries extends ITypedEntity {
 export interface IUrl extends IEntity {
   id: string,
   resource: string,
-  'relation-list'?: IRelationList[];
+  relations?: IRelationList[];
 }
 
 export interface IUrlMatch extends IMatch, IUrl {
 }
 
 export interface IUrlSearchResult extends ISearchResult {
-  urls?: IUrlMatch[];
+  urls: IUrlMatch[];
 }
 
 export interface IIsrcSearchResult extends ISearchResult {
@@ -766,4 +766,10 @@ export interface IBrowseWorksResult {
   works: IReleaseGroup[];
   'work-count': number;
   'work-offset': number;
+}
+
+export interface IUrlLookupResult {
+  'url-offset': number;
+  'url-count': number;
+  urls: IUrl[];
 }

--- a/test/test-musicbrainz-api.ts
+++ b/test/test-musicbrainz-api.ts
@@ -136,7 +136,9 @@ const mbid = {
     DireStraitsRemastered: '1ae6c9bc-2931-4d75-bee4-3dc53dfd246a'
   },
   url: {
-    SpotifyLisboaMulata: 'c69556a6-7ded-4c54-809c-afb45a1abe7d'
+    SpotifyLisboaMulata: 'c69556a6-7ded-4c54-809c-afb45a1abe7d',
+    Formidable: '9b30672a-5f1f-492b-ae82-529c9aa9d4c7',
+    BigInJapan: 'e46c4635-a038-4d18-801c-8dcf67423b7c'
   }
 };
 
@@ -144,11 +146,18 @@ const spotify = {
   album: {
     RacineCarree: {
       id: '6uyslsVGFsHKzdGUosFwBM'
+    },
+    LisboaMulata: {
+      url: 'https://open.spotify.com/album/5PCfptvsmuFcxsMt86L6wn'
     }
   },
   track: {
     Formidable: {
-      id: '2AMysGXOe0zzZJMtH3Nizb'
+      id: '2AMysGXOe0zzZJMtH3Nizb',
+      url: 'https://open.spotify.com/track/2AMysGXOe0zzZJMtH3Nizb'
+    },
+    BigInJapan: {
+      url: 'https://open.spotify.com/track/78Teboqh9lPIxWlIW5RMQL'
     }
   }
 };
@@ -398,9 +407,8 @@ describe('MusicBrainz-api', function () {
       it('url', async () => {
         const url = await mbApi.lookup('url', mbid.url.SpotifyLisboaMulata);
         assert.strictEqual(url.id, mbid.url.SpotifyLisboaMulata);
-        assert.strictEqual(url.resource, 'https://open.spotify.com/album/5PCfptvsmuFcxsMt86L6wn');
+        assert.strictEqual(url.resource, spotify.album.LisboaMulata.url);
       });
-
 
       describe('event', () => {
         it('event', async () => {
@@ -427,6 +435,60 @@ describe('MusicBrainz-api', function () {
       });
 
     });
+
+    describe('Lookup URLs', () => {
+
+      it('single URLs', async () => {
+
+        const urlsResult = await mbApi.lookupUrl(spotify.track.BigInJapan.url);
+
+        assert.isDefined(urlsResult, 'Expect a result');
+        assert.strictEqual(urlsResult.id, mbid.url.BigInJapan, 'id');
+        assert.strictEqual(urlsResult.resource, spotify.track.BigInJapan.url, 'resource');
+      });
+
+      it('multiple URLs', async () => {
+        const urls = [
+          spotify.track.BigInJapan.url,
+          spotify.track.Formidable.url
+        ];
+
+        const urlsResult = await mbApi.lookupUrl(urls);
+
+        assert.isDefined(urlsResult, 'Expect a result');
+        assert.isArray(urlsResult.urls, 'urls');
+        assert.strictEqual(urlsResult.urls?.length, 2, 'urls.length');
+
+        expect(urlsResult.urls).to.deep.include({id: mbid.url.Formidable, resource: spotify.track.Formidable.url}, 'Formidable');
+        expect(urlsResult.urls).to.deep.include({id: mbid.url.BigInJapan, resource: spotify.track.BigInJapan.url}, 'BigInJapan');
+      });
+
+      it('array with single value', async () => {
+        const urls = [
+          spotify.track.BigInJapan.url,
+        ];
+
+        const urlsResult = await mbApi.lookupUrl(urls);
+
+        assert.isDefined(urlsResult, 'Expect a result');
+        assert.isArray(urlsResult.urls, 'urls');
+        assert.strictEqual(urlsResult.urls?.length, 1, 'urls.length');
+
+        expect(urlsResult.urls).to.deep.include({id: mbid.url.BigInJapan, resource: spotify.track.BigInJapan.url}, 'BigInJapan');
+      });
+
+      it('include relations', async () => {
+
+        const urlsResult = await mbApi.lookupUrl(spotify.track.BigInJapan.url, ["recording-rels"]);
+
+        assert.isDefined(urlsResult, 'Expect a result');
+        assert.strictEqual(urlsResult.id, mbid.url.BigInJapan, 'id');
+        assert.strictEqual(urlsResult.resource, spotify.track.BigInJapan.url, 'resource');
+        assert.isArray(urlsResult.relations, 'relations');
+      });
+
+    });
+
 
     describe('Browse', () => {
 


### PR DESCRIPTION
Introduces method `lookupUrl` which lookups URL entities for 1 or multiple URLs.

Implements this REST method: https://musicbrainz.org/doc/MusicBrainz_API#url_(by_text)

Resolves #1047 