### PR TITLE
Introduces new browse overloads with an optional inc parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ const urls = await mbApi.lookupUrl(['https://open.spotify.com/track/2AMysGXOe0zz
 or 
 
 ```js
-const url = await mbApi.lookupUrl('https://open.spotify.com/track/2AMysGXOe0zzZJMtH3Nizb']);
+const url = await mbApi.lookupUrl('https://open.spotify.com/track/2AMysGXOe0zzZJMtH3Nizb');
 ```
 
 Arguments:
@@ -149,11 +149,26 @@ Note that the return type is different, depending on if a single URL or an array
 ## Browse requests
 Browse requests are a direct lookup of all the entities directly linked to another entity ("directly linked" here meaning it does not include entities linked by a relationship).
 
+For example, browse _releases_:
+```js
+
+const artist_mbid = 'ab2528d9-719f-4261-8098-21849222a0f2';
+
+const releases = await mbApi.browse('release', {
+    track_artist:  artist_mbid,
+    limit: 0,
+    offset: 0,
+  }, ['url-rels', 'isrcs', 'recordings']);
+```
+
+For the optional include arguments (`string[]`), see [Include arguments](#include-arguments).
+
 ### Browse artist
 
 ```js
 const artists = await mbApi.browse('artist', query);
-````
+const artists = await mbApi.browse('artist', query, ['area', 'collection']);
+```
 
 | Query argument        | Query value        | 
 |-----------------------|--------------------|  
@@ -167,7 +182,8 @@ const artists = await mbApi.browse('artist', query);
 ### Browse collection
 ```js
 const collections = await mbApi.browse('collection', query);
-````
+const collections = await mbApi.browse('collection', query, ['area', 'artist']);
+```
 
 | Query argument        | Query value        | 
 |-----------------------|--------------------|  
@@ -185,7 +201,8 @@ const collections = await mbApi.browse('collection', query);
 ### Browse events
 ```js
 const events = await mbApi.browse('event', query);
-````
+const events = await mbApi.browse('instrument', query, ['area', 'artist']);
+```
 
 | Query argument        | Query value     | 
 |-----------------------|-----------------|  
@@ -197,7 +214,8 @@ const events = await mbApi.browse('event', query);
 ### Browse instruments
 ```js
 const instruments = await mbApi.browse('instrument', query);
-````
+const instruments = await mbApi.browse('instrument', query, ['collection']);
+```
 
 | Query argument        | Query value        | 
 |-----------------------|--------------------|  
@@ -206,7 +224,8 @@ const instruments = await mbApi.browse('instrument', query);
 ### Browse labels
 ```js
 const labels = await mbApi.browse('label', query);
-````
+const places = await mbApi.browse('place', query, ['area', 'collection']);
+```
 
 | Query argument     | Query value     | 
 |--------------------|-----------------|  
@@ -217,7 +236,8 @@ const labels = await mbApi.browse('label', query);
 ### Browse places
 ```js
 const places = await mbApi.browse('place', query);
-````
+const places = await mbApi.browse('place', query, ['area', 'collection']);
+```
 
 | Query argument     | Query value     | 
 |--------------------|-----------------|  
@@ -226,8 +246,8 @@ const places = await mbApi.browse('place', query);
 
 ### Browse recordings
 ```js
-const recordings = await mbApi.browse('recording', query);
-````
+const recordings = await mbApi.browse('recording', query, ['artist']);
+```
 
 | Query argument     | Query value     | 
 |--------------------|-----------------|  
@@ -239,7 +259,8 @@ const recordings = await mbApi.browse('recording', query);
 ### Browse releases
 ```js
 const releases = await mbApi.browse('release', query);
-````
+const releases = await mbApi.browse('release', query, ['artist', 'track']);
+```
 
 | Query argument        | Query value        | 
 |-----------------------|--------------------|  
@@ -256,7 +277,8 @@ const releases = await mbApi.browse('release', query);
 
 ### Browse release-groups
 ```js
-const releaseGroups = await mbApi.browse('release-group',query);
+const releaseGroups = await mbApi.browse('release-group', query);
+const releaseGroups = await mbApi.browse('release-group', query, ['artist', 'release']);
 ```
 
 | Query argument     | Query value     | 
@@ -268,7 +290,8 @@ const releaseGroups = await mbApi.browse('release-group',query);
 ### Browse series
 ```js
 const series = await mbApi.browse('series');
-````
+const series = await mbApi.browse('series', ['collection']);
+```
 
 | Query argument        | Query value        | 
 |-----------------------|--------------------|  
@@ -286,7 +309,8 @@ const series = await mbApi.browse('series');
 ### Browse works
 ```js
 const works = await mbApi.browse('work');
-````
+const series = await mbApi.browse('series', ['artist', 'collection']);
+```
 
 | Query argument     | Query value     | 
 |--------------------|-----------------|  
@@ -296,7 +320,8 @@ const works = await mbApi.browse('work');
 ### Browse urls
 ```js
 const urls = await mbApi.browse('url');
-````
+const series = await mbApi.browse('series', ['artist', 'collection', 'artist-rels']);
+```
 
 | Query argument     | Query value     | 
 |--------------------|-----------------|  
@@ -305,7 +330,7 @@ const urls = await mbApi.browse('url');
 
 ## Search (query)
 
-Implements [XML Web Service/Version 2/Search](https://wiki.musicbrainz.org/Development/XML_Web_Service/Version_2/Search).
+Implements [MusicBrainz API: Search](https://wiki.musicbrainz.org/MusicBrainz_API/Search).
 
 There are different search fields depending on the entity.
 
@@ -338,21 +363,21 @@ const result = await mbApi.search('release-group', {query});
 
 ```js
  mbApi.search('area', 'Île-de-France');
-````
+```
 
 ##### Example: search release by barcode
 
 Search a release with the barcode 602537479870:
 ```js
  mbApi.search('release', {query: {barcode: 602537479870}});
-````
+```
 
 ##### Example: search by object
 
 Same as previous example, but automatically serialize parameters to search query
 ```js
  mbApi.search('release', 'barcode: 602537479870');
-````
+```
 
 ##### Example: search artist by artist name
 
@@ -447,9 +472,9 @@ As such, keep in mind requesting "artist-rels" for an artist, "release-rels" for
 In a release request, you might also be interested on relationships for the recordings linked to the release, or the release group linked to the release, or even for the works linked to those recordings that are linked to the release (for example, to find out who played guitar on a specific track, who wrote the lyrics for the song being performed, or whether the release group is part of a series). Similarly, for a recording request, you might want to get the relationships for any linked works. 
 There are three additional includes for this:
 
-- recording-level-rels
-- release-group-level-rels (for releases only)
-- work-level-rels
+- `recording-level-rels`
+- `release-group-level-rels` (for releases only)
+- `work-level-rels`
 
 # Submitting data via XML POST
 

--- a/lib/musicbrainz.types.ts
+++ b/lib/musicbrainz.types.ts
@@ -1,6 +1,7 @@
 import DateTimeFormat = Intl.DateTimeFormat;
 import type {IFormData} from './musicbrainz-api.js';
 
+
 export interface IPeriod {
   'begin': string;
   'ended': boolean;
@@ -659,6 +660,7 @@ export interface IBrowseReleasesQuery extends IPagination {
   recording?: string;
   release?: string;
   'release-group'?: string;
+  track_artist?: string;
   work?: string;
 }
 

--- a/test/test-musicbrainz-api.ts
+++ b/test/test-musicbrainz-api.ts
@@ -29,8 +29,8 @@ import { readFile } from 'node:fs/promises';
 import sinon from 'sinon';
 import type { HttpClient } from "../lib/http-client.js";
 import { RateLimitThreshold } from 'rate-limit-threshold';
-import {MusicBrainzApi as MusicBrainzApiDefault} from "../lib/musicbrainz-api.js";
-import {MusicBrainzApi as MusicBrainzApiNode} from "../lib/musicbrainz-api-node.js";
+import { MusicBrainzApi as MusicBrainzApiDefault } from "../lib/musicbrainz-api.js";
+import { MusicBrainzApi as MusicBrainzApiNode } from "../lib/musicbrainz-api-node.js";
 
 const appUrl = 'https://github.com/Borewit/musicbrainz-api';
 
@@ -278,7 +278,7 @@ describe('MusicBrainz-api', function () {
           assert.strictEqual(release.title, 'Anomalie');
         });
 
-        const includes: {inc: ReleaseIncludes, key: keyof IRelease}[] = [
+        const includes: { inc: ReleaseIncludes, key: keyof IRelease }[] = [
           {inc: 'artist-credits', key: 'artist-credit'},
           {inc: 'artists', key: 'artist-credit'},
           {inc: 'collections', key: 'collections'},
@@ -307,7 +307,7 @@ describe('MusicBrainz-api', function () {
           assert.strictEqual(releaseGroup.title, 'Formidable');
         });
 
-        const includes: {inc: ReleaseGroupIncludes, key: keyof IReleaseGroup}[] = [
+        const includes: { inc: ReleaseGroupIncludes, key: keyof IReleaseGroup }[] = [
           {inc: 'artist-credits', key: 'artist-credit'}
         ];
 
@@ -350,7 +350,7 @@ describe('MusicBrainz-api', function () {
           assert.isUndefined(recording.releases);
         });
 
-        const includes:{inc: RecordingIncludes, key: keyof IRecording}[] = [
+        const includes: { inc: RecordingIncludes, key: keyof IRecording }[] = [
           {inc: 'isrcs', key: 'isrcs'},
           {inc: 'artist-credits', key: 'artist-credit'},
           {inc: 'artists', key: 'artist-credit'},
@@ -459,8 +459,14 @@ describe('MusicBrainz-api', function () {
         assert.isArray(urlsResult.urls, 'urls');
         assert.strictEqual(urlsResult.urls?.length, 2, 'urls.length');
 
-        expect(urlsResult.urls).to.deep.include({id: mbid.url.Formidable, resource: spotify.track.Formidable.url}, 'Formidable');
-        expect(urlsResult.urls).to.deep.include({id: mbid.url.BigInJapan, resource: spotify.track.BigInJapan.url}, 'BigInJapan');
+        expect(urlsResult.urls).to.deep.include({
+          id: mbid.url.Formidable,
+          resource: spotify.track.Formidable.url
+        }, 'Formidable');
+        expect(urlsResult.urls).to.deep.include({
+          id: mbid.url.BigInJapan,
+          resource: spotify.track.BigInJapan.url
+        }, 'BigInJapan');
       });
 
       it('array with single value', async () => {
@@ -474,7 +480,10 @@ describe('MusicBrainz-api', function () {
         assert.isArray(urlsResult.urls, 'urls');
         assert.strictEqual(urlsResult.urls?.length, 1, 'urls.length');
 
-        expect(urlsResult.urls).to.deep.include({id: mbid.url.BigInJapan, resource: spotify.track.BigInJapan.url}, 'BigInJapan');
+        expect(urlsResult.urls).to.deep.include({
+          id: mbid.url.BigInJapan,
+          resource: spotify.track.BigInJapan.url
+        }, 'BigInJapan');
       });
 
       it('include relations', async () => {
@@ -500,7 +509,7 @@ describe('MusicBrainz-api', function () {
       }
 
       describe('area', async () => {
-        function areBunchOfAreas(areas : mb.IBrowseAreasResult) {
+        function areBunchOfAreas(areas: mb.IBrowseAreasResult) {
           areBunchOf('area', areas);
         }
 
@@ -553,7 +562,6 @@ describe('MusicBrainz-api', function () {
           areBunchOfArtists(artists);
           assert.strictEqual(artists.artists[0].name, 'Dead Combo');
         });
-
       });
 
       describe('collection', () => {
@@ -712,6 +720,26 @@ describe('MusicBrainz-api', function () {
           areBunchOfReleases(releases);
         });
 
+        it('by track_artist', async () => {
+          const releases = await mbApi.browse('release', {
+            track_artist: mbid.artist.Stromae,
+            limit: 0,
+            offset: 0
+          });
+
+          areBunchOfReleases(releases);
+        });
+
+        it('by track_artist, with includes', async () => {
+          const releases = await mbApi.browse('release', {
+            track_artist: mbid.artist.Stromae,
+            limit: 0,
+            offset: 0,
+          }, ['url-rels', 'isrcs', 'recordings']);
+
+          areBunchOfReleases(releases);
+        });
+
         it('by labels', async () => {
           const releases = await mbApi.browse('release', {label: mbid.label.Mosaert, limit: 3});
           areBunchOfReleases(releases);
@@ -726,6 +754,7 @@ describe('MusicBrainz-api', function () {
           const releases = await mbApi.browse('release', {'release-group': mbid.releaseGroup.Formidable, limit: 3});
           areBunchOfReleases(releases);
         });
+
       });
 
       describe('release-group', () => {
@@ -836,11 +865,11 @@ describe('MusicBrainz-api', function () {
 
           const artistRelations = new Map<string, IArtist>(); // Set to track unique relations
 
-          for(const media of release.media) {
-            for(const track of media.tracks) {
+          for (const media of release.media) {
+            for (const track of media.tracks) {
               const recording = await mbApi.lookup('recording', track.recording.id, ['artists', 'artist-rels']);
               assert.exists(recording.relations, 'recording.relations');
-              for(const relation of recording.relations) {
+              for (const relation of recording.relations) {
                 if (relation.artist) {
                   const relationKey = `${relation.type}/${relation.artist.name}`; // Create a unique key
                   if (!artistRelations.has(relationKey)) {
@@ -1033,7 +1062,7 @@ describe('MusicBrainz-api', function () {
 
       beforeEach(() => {
         // Stub to avoid unnecessary HTTP requests in the context of these tests
-        const x = mbApi as unknown as {httpClient: HttpClient};
+        const x = mbApi as unknown as { httpClient: HttpClient };
         sinon.stub(x.httpClient, "get").resolves(new Response('{}'));
       });
 
@@ -1067,7 +1096,7 @@ describe('MusicBrainz-api', function () {
 
       beforeEach(() => {
         // Stub to avoid unecessary HTTP requests in the context of these tests
-        const x = mbApi as unknown as {httpClient: HttpClient};
+        const x = mbApi as unknown as { httpClient: HttpClient };
         sinon.stub(x.httpClient, "post").resolves(new Response('{}'));
       });
 
@@ -1095,7 +1124,7 @@ describe('MusicBrainz-api', function () {
 
       beforeEach(() => {
         // Stub to avoid unnecessary HTTP requests in the context of these tests
-        const x = mbApi as unknown as {httpClient: HttpClient};
+        const x = mbApi as unknown as { httpClient: HttpClient };
         sinon.stub(x.httpClient, "post").resolves(new Response());
       });
 
@@ -1126,7 +1155,7 @@ describe('MusicBrainz-api', function () {
 
 });
 
-describe('Cover Art Archive API', function() {
+describe('Cover Art Archive API', function () {
 
   // Base URL used by cover-art-archive to refer back to MusicBrainz release
   // The addresses are normalized to https by `CoverArtArchiveApi`
@@ -1175,7 +1204,7 @@ describe('Cover Art Archive API', function() {
   });
 
   it('Failure test for the content type of the api', async () => {
-    const response = await fetch('https://coverartarchive.org/release/a8d5bd1b-e325-462d-af75-13ff94353101',{
+    const response = await fetch('https://coverartarchive.org/release/a8d5bd1b-e325-462d-af75-13ff94353101', {
       method: "GET",
       headers: {
         Accept: "application/json",
@@ -1189,7 +1218,7 @@ describe('Cover Art Archive API', function() {
 
 });
 
-describe.skip('Node specific API', function (){
+describe.skip('Node specific API', function () {
 
   let mbTestApi: MusicBrainzApiNode;
   let mbApi: MusicBrainzApiNode;


### PR DESCRIPTION
Changes:
- Introduces new **browse** overloads with an optional inc parameter.
  ```js
  const artist_mbid = 'ab2528d9-719f-4261-8098-21849222a0f2';

  const releases = await mbApi.browse('release', {
    artist:  artist_mbid,
    limit: 0,
    offset: 0,
  }, ['url-rels', 'isrcs', 'recordings']);
  ```
- Adds support for filtering releases by `track_artist`.
   for example:
  ```js
  const artist_mbid = 'ab2528d9-719f-4261-8098-21849222a0f2';

  const releases = await mbApi.browse('release', {
    track_artist:  artist_mbid,
  });
  ```
- Corrects documentation examples and links.


Resolves #1051