### PR TITLE
Add missing search entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,14 +340,21 @@ Searches can be performed using the generic search function: `query(entity: mb.E
 
 Arguments:
 - Entity type, which can be one of:
-  - `artist`: [search fields](https://wiki.musicbrainz.org/Development/XML_Web_Service/Version_2/Search#Artist)
-  - `label`: [search fields](https://wiki.musicbrainz.org/Development/XML_Web_Service/Version_2/Search#Label)
-  - `recording`: [search fields](https://wiki.musicbrainz.org/Development/XML_Web_Service/Version_2/Search#Recording)
-  - `release`: [search fields](https://wiki.musicbrainz.org/Development/XML_Web_Service/Version_2/Search#Release)
-  - `release-group`: [search fields](https://wiki.musicbrainz.org/Development/XML_Web_Service/Version_2/Search#Release_Group)
-  - `work`: [search fields](https://wiki.musicbrainz.org/Development/XML_Web_Service/Version_2/Search#Work)
-  - `area`: [search fields](https://wiki.musicbrainz.org/Development/XML_Web_Service/Version_2/Search#Area)
-  - `url`: [search fields](https://wiki.musicbrainz.org/Development/XML_Web_Service/Version_2/Search#URL)
+  - `annotation`: [search fields](https://wiki.musicbrainz.org/MusicBrainz_API/Search#Annotation)
+  - `area`: [search fields](https://wiki.musicbrainz.org/MusicBrainz_API/Search#Area)
+  - `artist`: [search fields](https://wiki.musicbrainz.org/MusicBrainz_API/Search#Artist)
+  - `cdstub`: [search fields](https://wiki.musicbrainz.org/MusicBrainz_API/Search#CDStubs)
+  - `event`: [search fields](https://wiki.musicbrainz.org/MusicBrainz_API/Search#Event)
+  - `instrument`: [search fields](https://wiki.musicbrainz.org/MusicBrainz_API/Search#Instrument)
+  - `label`: [search fields](https://wiki.musicbrainz.org/MusicBrainz_API/Search#Label)
+  - `place`: [search fields](https://wiki.musicbrainz.org/MusicBrainz_API/Search#Place)
+  - `recording`: [search fields](https://wiki.musicbrainz.org/MusicBrainz_API/Search#Recording)
+  - `release`: [search fields](https://wiki.musicbrainz.org/MusicBrainz_API/Search#Release)
+  - `release-group`: [search fields](https://wiki.musicbrainz.org/MusicBrainz_API/Search#Release_Group)
+  - `series`: [search fields](https://wiki.musicbrainz.org/MusicBrainz_API/Search#Series)
+  - `tag`: [search fields](https://wiki.musicbrainz.org/MusicBrainz_API/Search#Tag)
+  - `url`: [search fields](https://wiki.musicbrainz.org/MusicBrainz_API/Search#URL)
+  - `work`: [search fields](https://wiki.musicbrainz.org/MusicBrainz_API/Search#Work)
 - `query {query: string, offset: number, limit: number}`
   - `query.query`: supports the full Lucene Search syntax; you can find a detailed guide at [Lucene Search Syntax](https://lucene.apache.org/core/4_3_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#package_description). For example, you can set conditions while searching for a name with the AND operator.
   - `query.offset`: optional, return search results starting at a given offset. Used for paging through more than one page of results.

--- a/lib/musicbrainz-api.ts
+++ b/lib/musicbrainz-api.ts
@@ -300,17 +300,25 @@ export class MusicBrainzApi {
 
   /**
    * Search an entity using a search query
-   * @param query e.g.: '" artist: Madonna, track: Like a virgin"' or object with search terms: {artist: Madonna}
    * @param entity e.g. 'recording'
-   * @param query Arguments
+   * @param query e.g.: '" artist: Madonna, track: Like a virgin"' or object with search terms: {artist: Madonna}
    */
+  public search(entity: 'annotation', query: mb.ISearchQuery<(MiscIncludes | RelationsIncludes)>): Promise<mb.IAnnotationList>;
   public search(entity: 'area', query: mb.ISearchQuery<AreaIncludes> & mb.ILinkedEntitiesArea): Promise<mb.IAreaList>;
-  public search(artist: 'artist', query: mb.ISearchQuery<ArtistIncludes> & mb.ILinkedEntitiesArea): Promise<mb.IArtistList>;
-  public search(artist: 'recording', query: mb.ISearchQuery<AreaIncludes> & mb.ILinkedEntitiesArea): Promise<mb.IRecordingList>;
-  public search(artist: 'release', query: mb.ISearchQuery<ReleaseIncludes> & mb.ILinkedEntitiesArea): Promise<mb.IReleaseList>;
-  public search(artist: 'release-group', query: mb.ISearchQuery<ReleaseGroupIncludes> & mb.ILinkedEntitiesArea): Promise<mb.IReleaseGroupList>;
-  public search(artist: 'url', query: mb.ISearchQuery<UrlIncludes> & mb.ILinkedEntitiesArea): Promise<mb.IUrlList>;
-  public search<T extends mb.ISearchResult, I extends string = never>(entity: mb.EntityType, query: mb.ISearchQuery<I>): Promise<T> {
+  public search(entity: 'artist', query: mb.ISearchQuery<ArtistIncludes> & mb.ILinkedEntitiesArea): Promise<mb.IArtistList>;
+  public search(entity: 'cdstub', query: mb.ISearchQuery<(MiscIncludes | RelationsIncludes)>): Promise<mb.ICdStubList>;
+  public search(entity: 'event', query: mb.ISearchQuery<EventIncludes> & mb.ILinkedEntitiesEvent): Promise<mb.IEventList>;
+  public search(entity: 'instrument', query: mb.ISearchQuery<InstrumentIncludes> & mb.ILinkedEntitiesInstrument): Promise<mb.IInstrumentList>;
+  public search(entity: 'label', query: mb.ISearchQuery<LabelIncludes> & mb.ILinkedEntitiesLabel): Promise<mb.ILabelList>;
+  public search(entity: 'place', query: mb.ISearchQuery<PlaceIncludes> & mb.ILinkedEntitiesPlace): Promise<mb.IPlaceList>;
+  public search(entity: 'recording', query: mb.ISearchQuery<RecordingIncludes> & mb.ILinkedEntitiesArea): Promise<mb.IRecordingList>;
+  public search(entity: 'release', query: mb.ISearchQuery<ReleaseIncludes> & mb.ILinkedEntitiesArea): Promise<mb.IReleaseList>;
+  public search(entity: 'release-group', query: mb.ISearchQuery<ReleaseGroupIncludes> & mb.ILinkedEntitiesArea): Promise<mb.IReleaseGroupList>;
+  public search(entity: 'series', query: mb.ISearchQuery<SeriesIncludes> & mb.ILinkedEntitiesSeries): Promise<mb.ISeriesList>;
+  public search(entity: 'tag', query: mb.ISearchQuery<MiscIncludes | RelationsIncludes>): Promise<mb.ITagList>;
+  public search(entity: 'url', query: mb.ISearchQuery<UrlIncludes> & mb.ILinkedEntitiesUrl): Promise<mb.IUrlList>;
+  public search(entity: 'work', query: mb.ISearchQuery<WorkIncludes> & mb.ILinkedEntitiesWork): Promise<mb.IWorkList>;
+  public search<T extends mb.ISearchResult, I extends string = never>(entity: mb.EntityType | mb.OtherEntityTypes, query: mb.ISearchQuery<I>): Promise<T> {
     const urlQuery: any = {...query};
     if (typeof query.query === 'object') {
       urlQuery.query = makeAndQueryString(query.query);

--- a/lib/musicbrainz.types.ts
+++ b/lib/musicbrainz.types.ts
@@ -24,6 +24,13 @@ export interface LifeSpan {
   end: null | string
 }
 
+export interface IAnnotation {
+  entity: string;
+  name: string;
+  text: string;
+  type: string;
+}
+
 export interface IArea extends ITypedEntity {
   type: 'Country' | 'Subdivision' | 'Municipality' | 'City' | 'District' | 'Island'
   'iso-3166-1-codes'?: string[];
@@ -70,6 +77,14 @@ export interface IArtist extends ITypedEntity {
    */
   releases?: IRelease[];
   'release-groups'?: IReleaseGroup[];
+}
+
+export interface ICdStub {
+  id: string;
+  title: string;
+  artist: string;
+  barcode: string;
+  comment: string;
 }
 
 export interface IArtistCredit {
@@ -166,6 +181,7 @@ export interface IRelease extends IEntity {
   'release-group'?: IReleaseGroup; // Include: 'release-groups'
   collections?: ICollection[],
   'track-count'?: number;
+  count?: number;
 }
 
 export interface IReleaseEvent {
@@ -229,52 +245,87 @@ export interface IReleaseGroup extends IEntity {
   releases?: IRelease[]; // include 'releases'
 }
 
-export interface IAreaMatch extends IArea, IMatch {
-}
-
-export interface IArtistMatch extends IArtist, IMatch {
-}
-
-export interface IRecordingMatch extends IRecording, IMatch {
-}
-
-export interface IReleaseGroupMatch extends IReleaseGroup, IMatch {
-}
-
-export interface IReleaseMatch extends IRelease, IMatch {
-  count: number;
-}
-
 export interface ISearchResult {
   created: DateTimeFormat;
   count: number;
   offset: number;
 }
 
-export interface IArtistList extends ISearchResult {
-  artists: IArtistMatch[];
+export type IAnnotationMatch = IAnnotation & IMatch;
+export interface IAnnotationList extends ISearchResult {
+  annotations: IAnnotationMatch[];
 }
 
+export type IAreaMatch = IArea & IMatch;
 export interface IAreaList extends ISearchResult {
   areas: IAreaMatch[];
 }
 
+export type IArtistMatch = IArtist & IMatch;
+export interface IArtistList extends ISearchResult {
+  artists: IArtistMatch[];
+}
+
+export type ICdStubMatch = ICdStub & IMatch;
+export interface ICdStubList extends ISearchResult {
+  cdstubs: ICdStubMatch[];
+}
+
+export type IEventMatch = IEvent & IMatch;
+export interface IEventList extends ISearchResult {
+  events: IEventMatch[];
+}
+
+export type IInstrumentMatch = IInstrument & IMatch;
+export interface IInstrumentList extends ISearchResult {
+  instruments: IInstrumentMatch[];
+}
+
+export type ILabelMatch = ILabel & IMatch;
+export interface ILabelList extends ISearchResult {
+  labels: ILabelMatch[];
+}
+
+export type IPlacesMatch = IPlace & IMatch;
+export interface IPlaceList extends ISearchResult {
+  places: IPlacesMatch[];
+}
+
+export type IReleaseMatch = IRelease & IMatch;
 export interface IReleaseList extends ISearchResult {
   releases: IReleaseMatch[];
   'release-count': number;
 }
 
+export type IRecordingMatch = IRecording & IMatch;
 export interface IRecordingList extends ISearchResult {
   recordings: IRecordingMatch[];
   'recordings-count': number;
 }
 
+export type IReleaseGroupMatch = IReleaseGroup & IMatch;
 export interface IReleaseGroupList extends ISearchResult {
   'release-groups': IReleaseGroupMatch[];
 }
 
+export type ISeriesGroupMatch = ISeries & IMatch;
+export interface ISeriesList extends ISearchResult {
+  series: ISeriesGroupMatch[];
+}
+
+export type ITagMatch = ITag & IMatch;
+export interface ITagList extends ISearchResult {
+  tags: ITagMatch[];
+}
+
+export type IUrlMatch = IUrl & IMatch;
 export interface IUrlList extends ISearchResult {
   urls: IUrlMatch[];
+}
+
+export type IWorkMatch = IWork & IMatch;
+export interface IWorkList extends ISearchResult {
+  works: IWorkMatch[];
 }
 
 export type RelationDirection = 'backward' | 'forward';
@@ -327,22 +378,14 @@ export interface ISeries extends ITypedEntity {
   disambiguation: string;
 }
 
+export interface ITag {
+  name: string;
+}
+
 export interface IUrl extends IEntity {
   id: string,
   resource: string,
   relations?: IRelationList[];
-}
-
-export interface IUrlMatch extends IMatch, IUrl {
-}
-
-export interface IUrlSearchResult extends ISearchResult {
-  urls: IUrlMatch[];
-}
-
-export interface IIsrcSearchResult extends ISearchResult {
-  'isrc': string;
-  'recordings': IRecording[];
 }
 
 export interface IExernalIds {
@@ -354,9 +397,15 @@ export interface IReleaseSearchResult extends ISearchResult {
 }
 
 /**
+ * Entities without MBID
+ */
+export type OtherEntityTypes = 'annotation' | 'cdstub' | 'tag';
+
+/**
  * https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2#Subqueries
  */
-export type EntityType = 'area' |
+export type EntityType = 'annotation' |
+  'area' |
   'artist' |
   'collection' |
   'event' |
@@ -487,6 +536,14 @@ export interface ILinkedEntitiesLabel {
   area?: string;
   collection?: string;
   release?: string;
+}
+
+/**
+ * https://musicbrainz.org/doc/MusicBrainz_API#Subqueries
+ * /ws/2/place             area, collection, release
+ */
+export interface ILinkedEntitiesPlace {
+  place?: string;
 }
 
 /**


### PR DESCRIPTION
Add typings to search for the following entities:
- `annotation`
- `cdstub`
- `events`
- `instrument`
- `label`
- `place`
- `series`
- `tag`
- `work`

Resolves #1054 