### PR TITLE
Add support for release types in browse query.

### DIFF
--- a/lib/musicbrainz-api.ts
+++ b/lib/musicbrainz-api.ts
@@ -291,6 +291,12 @@ export class MusicBrainzApi {
       // Serialize include parameter
       query.inc = inc.join(' ');
     }
+    for(const pipedFilter of ['type', 'status']) {
+      if (query[pipedFilter]) {
+        // Serialize type parameter
+        query[pipedFilter] = query[pipedFilter].join('|');
+      }
+    }
     return this.restGet<T>(`/${entity}`, query);
   }
 

--- a/lib/musicbrainz.types.ts
+++ b/lib/musicbrainz.types.ts
@@ -428,6 +428,35 @@ export type Relationships = 'area-rels' |
   'url-rels' |
   'work-rels';
 
+/**
+ * Ref: https://musicbrainz.org/doc/MusicBrainz_API#Release_.28Group.29_Type_and_Status
+ */
+export type ReleaseStatusQuery = 'official' | 'promotion' | 'bootleg' | 'pseudo-release' |  'withdrawn' | 'cancelled';
+
+/**
+ * Ref: https://musicbrainz.org/doc/MusicBrainz_API#Release_.28Group.29_Type_and_Status
+ */
+export type ReleaseTypeQuery = 'album'
+  | 'single'
+  | 'ep'
+  | 'broadcast'
+  | 'other'
+  | 'audiobook'
+  | 'compilation'
+  | 'demo'
+  | 'dj-mix'
+  | 'field recording'
+  | 'interview'
+  | 'live'
+  | 'mixtape/street'
+  | 'remix'
+  | 'soundtrack'
+  | 'spokenword';
+
+
+
+
+
 export enum LinkType {
   license = 302,
   production = 256,
@@ -453,6 +482,14 @@ export interface IPagination {
    * An integer value defining how many entries should be returned. Only values between 1 and 100 (both inclusive) are allowed. If not given, this defaults to 25.
    */
   limit?: number;
+}
+
+/**
+ * Release and release-group types
+ */
+export interface IReleaseTypeAndStatus {
+  status?: ReleaseStatusQuery[];
+  type?: ReleaseTypeQuery[];
 }
 
 /**
@@ -634,7 +671,7 @@ interface BrowseReleasesEntityParams {
   track_artist: string;
   work: string;
 }
-export type IBrowseReleasesQuery = IPagination & OneOf<BrowseReleasesEntityParams>;
+export type IBrowseReleasesQuery = IPagination & IReleaseTypeAndStatus & OneOf<BrowseReleasesEntityParams>;
 
 /**
  * List of entity names allowed for browsing artists by a single MBID.
@@ -722,7 +759,7 @@ interface BrowseReleaseGroupsEntityParams {
   collection: string;
   release: string;
 }
-export type IBrowseReleaseGroupsQuery = IPagination & OneOf<BrowseReleaseGroupsEntityParams>;
+export type IBrowseReleaseGroupsQuery = IPagination & IReleaseTypeAndStatus & OneOf<BrowseReleaseGroupsEntityParams>;
 
 /**
  * List of entity names allowed for browsing works by a single MBID.

--- a/test/test-musicbrainz-api.ts
+++ b/test/test-musicbrainz-api.ts
@@ -757,6 +757,11 @@ describe('MusicBrainz-api', function () {
           areBunchOfReleases(releases);
         });
 
+        it('by release group type and status', async () => {
+          const releases = await mbApi.browse('release', {artist: mbid.artist.Stromae, limit: 3, type: ['single'], status: ['official']});
+          areBunchOfReleases(releases);
+        });
+
       });
 
       describe('release-group', () => {
@@ -778,6 +783,15 @@ describe('MusicBrainz-api', function () {
         it('by release', async () => {
           const releaseGroups = await mbApi.browse('release-group', {release: mbid.release.Formidable, limit: 3});
           areBunchOfReleaseGroups(releaseGroups);
+        });
+
+
+        it('for a release type', async () => {
+          const releaseGroups = await mbApi.browse('release-group', {artist: mbid.artist.Stromae, type: ['single'], limit: 3});
+          // Are singles
+          for(const releaseGroup of releaseGroups["release-groups"]) {
+            assert.strictEqual(releaseGroup["primary-type"], 'Single');
+          }
         });
 
       });


### PR DESCRIPTION
Resolves #1090

Adds support for filtering _releases_ and _release-groups_ by type and status in the MusicBrainz API browse functionality. The changes enable clients to query for specific release types (e.g., `'single'`, `'album'`) and statuses (e.g., `'official'`, `'bootleg'`) when browsing entities.
- Added type definitions for `ReleaseTypeQuery` and `ReleaseStatusQuery` with all valid values
- Extended browse query types for releases and release-groups to include type and status filters
- Implemented serialization logic to convert type/status arrays to pipe-delimited strings for the API
- Added test cases to verify the new filtering functionality works correctly

Example:
 ```ts
 const releaseGroups = await mbApi.browse('release-group', {artist: mbid.artist.Stromae, type: ['single', 'ep'], status: ['official'], limit: 10});
 ```
 Ref:
 - https://musicbrainz.org/doc/MusicBrainz_API#Release_.28Group.29_Type_and_Status
 