### PR TITLE
Fix appMail mention in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ const config = {
     // Required: Application details
     appName: 'my-app',
     appVersion: '0.1.0',
-    appMail: 'user@mail.org',
+    appContactInfo: 'user@mail.org',
 
     // Optional: Proxy settings (default: no proxy server)
     proxy: {


### PR DESCRIPTION
`appMail` was generally changed to `appContactInfo` in this commit:

    commit 48889260a5b4057b92c2d31ff39cbb9a134855af
    Author: Borewit <borewit@users.noreply.github.com>
    Date:   Sun Jun 30 13:38:01 2019 +0200

        Update API to use config.appContactInfo (which supposed to be e-mail or URL)

This commit updates the final remaining mention of `appMail`.