### PR TITLE
Improve error reporting for 400 Bad Request responses

### DIFF
--- a/test/test-musicbrainz-api.ts
+++ b/test/test-musicbrainz-api.ts
@@ -142,7 +142,7 @@ const mbid = {
     Formidable: '9b30672a-5f1f-492b-ae82-529c9aa9d4c7',
     BigInJapan: 'e46c4635-a038-4d18-801c-8dcf67423b7c'
   },
-  genre : {
+  genre: {
     DancePop: 'b739a895-85ed-4ad3-8717-4e9ef5387dd8'
   }
 };
@@ -767,7 +767,12 @@ describe('MusicBrainz-api', function () {
         });
 
         it('by release group type and status', async () => {
-          const releases = await mbApi.browse('release', {artist: mbid.artist.Stromae, limit: 3, type: ['single'], status: ['official']});
+          const releases = await mbApi.browse('release', {
+            artist: mbid.artist.Stromae,
+            limit: 3,
+            type: ['single'],
+            status: ['official']
+          });
           areBunchOfReleases(releases);
         });
 
@@ -796,9 +801,13 @@ describe('MusicBrainz-api', function () {
 
 
         it('for a release type', async () => {
-          const releaseGroups = await mbApi.browse('release-group', {artist: mbid.artist.Stromae, type: ['single'], limit: 3});
+          const releaseGroups = await mbApi.browse('release-group', {
+            artist: mbid.artist.Stromae,
+            type: ['single'],
+            limit: 3
+          });
           // Are singles
-          for(const releaseGroup of releaseGroups["release-groups"]) {
+          for (const releaseGroup of releaseGroups["release-groups"]) {
             assert.strictEqual(releaseGroup["primary-type"], 'Single');
           }
         });


### PR DESCRIPTION
### Summary

This PR improves how the client surfaces MusicBrainz API errors for
HTTP 400 (Bad Request) responses.

Resolves #1131 

When a 400 response is returned, the JSON error payload provided by
MusicBrainz is now parsed and exposed via a `MusicBrainzApiError`
instead of being treated as a successful result.

### Scope

This change intentionally targets **400 responses only**.
Other HTTP status codes keep their existing behavior, as their response
shapes and semantics differ.

### What changed

- Detect HTTP 400 responses in `restGet`
- Parse the MusicBrainz JSON error payload when available
- Throw `MusicBrainzApiError` including status and response body
- Add unit test coverage for invalid MBID lookups

### Result

Invalid identifiers, such as malformed MBIDs, now fail fast with a
clear, structured error that is easier to diagnose and handle.

### Example

```ts
await lookup('area', 'invalid-mbid');
// throws MusicBrainzApiError (status 400)