### PR TITLE
feat: Implement retry limit configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ const config = {
     //           (default: 15 requests every 18 seconds)
     rateLimit: [15, 18],
     
-    // Optional: Set number of request retries for GET requests
+    // Optional: Set the maximum number of attempts for GET requests
     // Default 10
     retryLimit: 10
 };

--- a/README.md
+++ b/README.md
@@ -101,7 +101,11 @@ const config = {
 
     // Optional: Set max number of request with X seconds
     //           (default: 15 requests every 18 seconds)
-    rateLimit: [15, 18]
+    rateLimit: [15, 18],
+    
+    // Optional: Set number of request retries for GET requests
+    // Default 10
+    retryLimit: 10
 };
 
 const mbApi = new MusicBrainzApi(config);

--- a/lib/musicbrainz-api.ts
+++ b/lib/musicbrainz-api.ts
@@ -160,6 +160,12 @@ export interface IMusicBrainzConfig {
   * Default is [15, 18], which allows up to 15 requests every 18 seconds
   */
   rateLimit?: [number, number]
+  /**
+   * Number of times to retry a GET request
+   * 
+   * Default is 10
+   */
+  retryLimit?: number
 }
 
 interface IInternalConfig extends IMusicBrainzConfig {
@@ -264,7 +270,7 @@ export class MusicBrainzApi {
 
     const response = await this.httpClient.get(`/ws/2${relUrl}`, {
       query,
-      retryLimit: 10
+      retryLimit: this.config.retryLimit ?? 10
     });
 
     if(response.status === 400) {

--- a/lib/musicbrainz-api.ts
+++ b/lib/musicbrainz-api.ts
@@ -161,7 +161,7 @@ export interface IMusicBrainzConfig {
   */
   rateLimit?: [number, number]
   /**
-   * Number of times to retry a GET request
+   * Maximum number of attempts for a GET request.
    * 
    * Default is 10
    */


### PR DESCRIPTION
This configuration option allows users to set the number of retries made for GET and POST requests, rather than it being hardcoded to 10 and 1, respectively.