### PR TITLE
feat: Implement preRequest hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ const config = {
     // Optional: Set max number of request with X seconds
     //           (default: 15 requests every 18 seconds)
     rateLimit: [15, 18]
+
+    // Optional: A function to access and/or modify url/headers before the request is sent
+    preRequest: (method, url, headers) => {
+        console.log(url);
+        headers.set('My-Header-X', '123');
+        return [method, url, headers];
+    }
 };
 
 const mbApi = new MusicBrainzApi(config);

--- a/lib/http-client.ts
+++ b/lib/http-client.ts
@@ -18,6 +18,7 @@ export interface IHttpClientOptions {
   timeout: number;
   userAgent: string;
   followRedirects?: boolean;
+  preRequest?: (method: string, url: string, headers: Headers) => [string, string, Headers]
 }
 
 export interface IFetchOptions {
@@ -67,15 +68,20 @@ export class HttpClient {
 
     let retryLimit = options.retryLimit && options.retryLimit > 1 ? options.retryLimit : 1;
     const retryTimeout = this.httpOptions.timeout ? this.httpOptions.timeout : 500;
-    const url = this._buildUrl(path, options.query);
+    let url = this._buildUrl(path, options.query);
     const cookies = await this.getCookies();
 
-    const headers: HeadersInit = new Headers(options.headers);
+    let headers: HeadersInit = new Headers(options.headers);
     headers.set('User-Agent', this.httpOptions.userAgent);
     if (cookies !== null) {
       headers.set('Cookie', cookies);
     }
 
+    if(this.httpOptions.preRequest !== undefined) {
+        const [m, u, h] = this.httpOptions.preRequest(method, url, headers);
+        url = u;
+        headers = h;
+    }
     while (retryLimit > 0) {
       let response: Response;
       try {

--- a/lib/musicbrainz-api.ts
+++ b/lib/musicbrainz-api.ts
@@ -160,6 +160,11 @@ export interface IMusicBrainzConfig {
   * Default is [15, 18], which allows up to 15 requests every 18 seconds
   */
   rateLimit?: [number, number]
+
+  /**
+   * Optional function to access and/or modify URL and headers before request is sent
+   */
+  preRequest?: (method: string, url: string, headers: Headers) => [string, string, Headers]
 }
 
 interface IInternalConfig extends IMusicBrainzConfig {


### PR DESCRIPTION
This configuration option implements a hook that can be used just before a request is sent. It allows a user to inspect the url/headers of the request as well as modify the url/headers.

This option is super useful for logging the full URL (debugging query strings  for instance) or modifying headers to add custom authorization etc...