### PR TITLE
fix: Add singular track field to Medium and make it and tracks optional

### DIFF
--- a/lib/musicbrainz.types.ts
+++ b/lib/musicbrainz.types.ts
@@ -215,7 +215,8 @@ export interface IMedium {
   title: string;
   format?: string; // optional, type doesn't work
   'format-id': string;
-  tracks: ITrack[];
+  tracks?: ITrack[];
+  track?: ITrack[];
   'track-count': number;
   'track-offset': number;
   position: number;

--- a/test/test-musicbrainz-api.ts
+++ b/test/test-musicbrainz-api.ts
@@ -1228,7 +1228,7 @@ describe('MusicBrainz-api', function () {
               const artistRelations = new Map<string, IArtist>(); // Set to track unique relations
 
               for (const media of release.media) {
-                for (const track of media.tracks) {
+                for (const track of (media.tracks as mb.ITrack[])) {
                   const recording = await mbApi.lookup('recording', track.recording.id, ['artists', 'artist-rels']);
                   assert.exists(recording.relations, 'recording.relations');
                   for (const relation of recording.relations) {


### PR DESCRIPTION
Use this query

```
tid:\"c63b7e96\\-928c\\-48dd\\-b558\\-a181cb245cb6\"(arid:(\"3569c2ed\\-2315\\-40d9\\-b041\\-3c48dae1be43\") OR arid:(\"3569c2ed\\-2315\\-40d9\\-b041\\-3c48dae1be43\")) AND reid:\"cbc89dff\\-3555\\-498c\\-bb1e\\-2ff983b13e59\
```
when searching for recordings like `mb.search('recording', {query })`

results in this url

```
https://musicbrainz.org//ws/2/recording/?query=tid%3A%22c63b7e96%5C-928c%5C-48dd%5C-b558%5C-a181cb245cb6%22%28arid%3A%28%223569c2ed%5C-2315%5C-40d9%5C-b041%5C-3c48dae1be43%22%29+OR+arid%3A%28%223569c2ed%5C-2315%5C-40d9%5C-b041%5C-3c48dae1be43%22%29%29+AND+reid%3A%22cbc89dff%5C-3555%5C-498c%5C-bb1e%5C-2ff983b13e59%22&fmt=json
```
the first recording returned has a release with a medium that has `track` instead of `tracks`.

<img width="810" height="907" alt="image" src="https://github.com/user-attachments/assets/462bb5fe-bf25-493a-a9b3-fcc8424cc471" />

Probably because it only has one track? Even though `track` is still an `ITrack[]` shape.

Strangely, doing a lookup for the recording returns the correct shape with `tracks`

https://musicbrainz.org/ws/2/recording/f0443b71-044e-4d6e-a454-11ab0d925d47?inc=releases+media&fmt=json

So I'm not sure this is not actually a bug on the musicbrainz side of things. But I still think its worth adding `track` as a possible field and marking both as optional so that a musicbrainz-api user should properly guard against this.