### PR TITLE
Optimize Queen artist relations test

### DIFF
--- a/test/test-musicbrainz-api.ts
+++ b/test/test-musicbrainz-api.ts
@@ -1209,27 +1209,22 @@ describe('MusicBrainz-api', function () {
           // Based on https://stackoverflow.com/a/79369493/28701779
           it('Find all artist relations of Queen - Made in Heaven', async () => {
 
-            async function findReleaseGroup(artist: string, title: string) {
-              const result = await mbApi.search('release-group', {query: `artist:"${artist}" AND release:"${title}"`});
-              return result.count > 0 ? result["release-groups"][0] : undefined;
-            }
-
             /**
              * Find all artists for provided MBID (MusicBrainz ID)
-             * @param mbidReleaseGroup MBID (MusicBrainz ID) Release-group
+             * @param mbidRelease MBID (MusicBrainz ID) Release
              */
-            async function findAllRelatedArtist(mbidReleaseGroup: string): Promise<MapIterator<IArtist>> {
-              const relInfoGrp = await mbApi.lookup('release-group', mbidReleaseGroup, ['releases']);
-              assert.exists(relInfoGrp.releases, 'relInfoGrp.releases');
-              assert.isAtLeast(relInfoGrp.releases.length, 1, 'relInfoGrp.releases.length');
-              let release = relInfoGrp.releases[0]; // Pick the first (some) release from the release-group
-              release = await mbApi.lookup('release', release.id, ['artists', 'recordings']);
+            async function findAllRelatedArtist(mbidRelease: string): Promise<MapIterator<IArtist>> {
+              const release = await mbApi.lookup('release', mbidRelease, [
+                'recordings',
+                'recording-level-rels',
+                'artist-rels'
+              ]);
 
               const artistRelations = new Map<string, IArtist>(); // Set to track unique relations
 
               for (const media of release.media) {
                 for (const track of media.tracks) {
-                  const recording = await mbApi.lookup('recording', track.recording.id, ['artists', 'artist-rels']);
+                  const recording = track.recording;
                   assert.exists(recording.relations, 'recording.relations');
                   for (const relation of recording.relations) {
                     if (relation.artist) {
@@ -1244,20 +1239,16 @@ describe('MusicBrainz-api', function () {
               return artistRelations.values();
             }
 
-            const releaseGroup = await findReleaseGroup('Queen', 'Made in Heaven');
-            assert.isDefined(releaseGroup, 'Should be able to find the release-group for: Queen - Made in Heaven');
-            if (releaseGroup) {
-              const artists = Array.from(await findAllRelatedArtist(releaseGroup.id));
-              const artistNames = artists.map(artist => artist.name);
-              assert.include(artistNames, 'Queen');
-              assert.include(artistNames, 'Josh Macrae');
-              assert.include(artistNames, 'David Richards');
-              assert.include(artistNames, 'Justin Shirley‐Smith');
-              assert.include(artistNames, 'John Deacon');
-              assert.include(artistNames, 'Brian May');
-              assert.include(artistNames, 'Freddie Mercury');
-              assert.include(artistNames, 'Roger Taylor');
-            }
+            const artists = Array.from(await findAllRelatedArtist('97a776fd-9b24-4ada-9f52-81ef96ccf4b9'));
+            const artistNames = artists.map(artist => artist.name);
+            assert.include(artistNames, 'Queen');
+            assert.include(artistNames, 'Josh Macrae');
+            assert.include(artistNames, 'David Richards');
+            assert.include(artistNames, 'Justin Shirley‐Smith');
+            assert.include(artistNames, 'John Deacon');
+            assert.include(artistNames, 'Brian May');
+            assert.include(artistNames, 'Freddie Mercury');
+            assert.include(artistNames, 'Roger Taylor');
           });
         });
 


### PR DESCRIPTION
Optimizes the Queen artist-relations integration test to reduce MusicBrainz requests and avoid timeouts.

Changes:
- Uses a known release MBID directly.
- Fetches recording-level artist relations in one lookup.
- Removes per-recording API requests.