### PR TITLE
Bound HTTP retry attempts

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -80,6 +80,7 @@ jobs:
           MBUSER: ${{ secrets.MBUSER }}
           MBPWD: ${{ secrets.MBPWD }}
           TEST_TIMEOUT_SEC: ${{ vars.TEST_TIMEOUT_SEC }}
+          DEBUG: ${{ vars.DEBUG }}
         run: yarn run test-coverage
 
       - name: Coveralls Parallel

--- a/lib/http-client.ts
+++ b/lib/http-client.ts
@@ -13,7 +13,7 @@ export type MultiQueryFormData = { [key: string]: string | string[]; }
 export interface IHttpClientOptions {
   baseUrl: string,
   /**
-   * Retry time-out, default 500 ms
+   * Base retry delay in milliseconds. The delay increases linearly after each failed attempt.
    */
   timeout: number;
   userAgent: string;
@@ -22,6 +22,7 @@ export interface IHttpClientOptions {
 
 export interface IFetchOptions {
   query?: MultiQueryFormData;
+  /** Maximum number of attempts, including the initial request. */
   retryLimit?: number;
   body?: string;
   headers?: HeadersInit;
@@ -65,7 +66,9 @@ export class HttpClient {
   private async _fetch(method: string, path: string, options?: IFetchOptions): Promise<Response> {
     if (!options) options = {};
 
-    let retryLimit = options.retryLimit && options.retryLimit > 1 ? options.retryLimit : 1;
+    const maxAttempts = typeof options.retryLimit === 'number' && Number.isFinite(options.retryLimit)
+      ? Math.max(1, Math.floor(options.retryLimit))
+      : 1;
     const retryTimeout = this.httpOptions.timeout ? this.httpOptions.timeout : 500;
     const url = this._buildUrl(path, options.query);
     const cookies = await this.getCookies();
@@ -76,7 +79,13 @@ export class HttpClient {
       headers.set('Cookie', cookies);
     }
 
-    while (retryLimit > 0) {
+    let attempt = 0;
+    while (attempt < maxAttempts) {
+      if (attempt > 0) {
+        await this._delay(retryTimeout * attempt);
+      }
+      ++attempt;
+      const retryDelay = retryTimeout * attempt;
       let response: Response;
       try {
         response = await fetch(url, {
@@ -88,21 +97,18 @@ export class HttpClient {
         })
       } catch (err) {
         if (isConnectionReset(err)) {
-          // Retry on TCP connection resets
-          await this._delay(retryTimeout); // wait 200ms before retry
-          continue;
+          if (attempt < maxAttempts) {
+            debug(`Transient connection failure on attempt ${attempt}/${maxAttempts}: ${err instanceof Error ? err.message : 'unknown error'}; retry in ${retryDelay} ms`);
+            continue;
+          }
         }
         throw err;
       }
 
-      if (response.status === 429 || response.status === 503) {
-        debug(`Received status=${response.status}, assume reached rate limit, retry in ${retryTimeout} ms`);
-        retryLimit--;
-
-        if (retryLimit > 0) {
-          await this._delay(retryTimeout); // wait 200ms before retry
-          continue;
-        }
+      if ((response.status === 429 || response.status === 503) && attempt < maxAttempts) {
+        debug(`Received status=${response.status} on attempt ${attempt}/${maxAttempts}, retry in ${retryDelay} ms`);
+        await response.body?.cancel();
+        continue;
       }
 
       debug(`Received status=${response.status}`);
@@ -111,7 +117,7 @@ export class HttpClient {
       return response;
     }
 
-    throw new Error(`Failed to fetch ${url} after retries`);
+    throw new Error(`Failed to fetch ${url} after ${maxAttempts} attempts`);
   }
 
 // Helper: Builds URL with query string

--- a/lib/musicbrainz-api.ts
+++ b/lib/musicbrainz-api.ts
@@ -267,7 +267,7 @@ export class MusicBrainzApi {
       retryLimit: 10
     });
 
-    if(response.status === 400) {
+    if(!response.ok) {
 
       const body = await safeJson(response);
       const mb = (body ?? {}) as MusicBrainzErrorBody;

--- a/test/test-http-client.ts
+++ b/test/test-http-client.ts
@@ -1,0 +1,125 @@
+import {assert} from 'chai';
+import sinon from 'sinon';
+import {HttpClient} from '../lib/http-client.js';
+import {MusicBrainzApi, MusicBrainzApiError} from '../lib/musicbrainz-api.js';
+
+function makeClient(): HttpClient {
+  return new HttpClient({
+    baseUrl: 'https://example.test',
+    timeout: 1,
+    userAgent: 'musicbrainz-api/test'
+  });
+}
+
+function makeConnectionReset(): TypeError {
+  return Object.assign(new TypeError('fetch failed'), {cause: {code: 'ECONNRESET'}});
+}
+
+describe('HttpClient retry loop', () => {
+
+  let fetchStub: sinon.SinonStub;
+  let delayStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(globalThis, 'fetch');
+    delayStub = sinon.stub(
+      HttpClient.prototype as unknown as {_delay(ms: number): Promise<void>},
+      '_delay'
+    ).resolves();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('retries a connection reset', async () => {
+    fetchStub.onFirstCall().rejects(makeConnectionReset());
+    fetchStub.onSecondCall().resolves(new Response('{}'));
+
+    const response = await makeClient().get('/resource', {retryLimit: 2});
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(fetchStub.callCount, 2);
+    assert.isTrue(delayStub.calledOnceWithExactly(1));
+  });
+
+  it('rethrows the final connection reset', async () => {
+    const connectionReset = makeConnectionReset();
+    fetchStub.rejects(connectionReset);
+
+    let caughtError: unknown;
+    try {
+      await makeClient().get('/resource', {retryLimit: 3});
+    } catch (error) {
+      caughtError = error;
+    }
+
+    assert.strictEqual(caughtError, connectionReset);
+    assert.strictEqual(fetchStub.callCount, 3);
+    assert.strictEqual(delayStub.callCount, 2);
+  });
+
+  for (const status of [429, 503]) {
+    it(`returns the final HTTP ${status} response`, async () => {
+      fetchStub.callsFake(async () => new Response('', {status}));
+
+      const response = await makeClient().get('/resource', {retryLimit: 3});
+
+      assert.strictEqual(response.status, status);
+      assert.strictEqual(fetchStub.callCount, 3);
+      assert.strictEqual(delayStub.callCount, 2);
+    });
+  }
+
+  it('increases the delay after each failed attempt', async () => {
+    fetchStub.onCall(0).resolves(new Response('', {status: 503}));
+    fetchStub.onCall(1).resolves(new Response('', {status: 503}));
+    fetchStub.onCall(2).resolves(new Response('', {status: 503}));
+    fetchStub.onCall(3).resolves(new Response('{}'));
+
+    await makeClient().get('/resource', {retryLimit: 4});
+
+    assert.deepEqual(delayStub.args, [[1], [2], [3]]);
+  });
+
+  it('cancels a response body before retrying', async () => {
+    const retryResponse = new Response('', {status: 503});
+    const cancelSpy = sinon.spy(retryResponse.body as ReadableStream, 'cancel');
+    fetchStub.onFirstCall().resolves(retryResponse);
+    fetchStub.onSecondCall().resolves(new Response('{}'));
+
+    await makeClient().get('/resource', {retryLimit: 2});
+
+    assert.isTrue(cancelSpy.calledOnce);
+  });
+
+  it('uses one attempt for a non-finite retry limit', async () => {
+    fetchStub.resolves(new Response('', {status: 503}));
+
+    const response = await makeClient().get('/resource', {retryLimit: Number.POSITIVE_INFINITY});
+
+    assert.strictEqual(response.status, 503);
+    assert.strictEqual(fetchStub.callCount, 1);
+    assert.isFalse(delayStub.called);
+  });
+
+  it('throws a MusicBrainz API error for the final HTTP response', async () => {
+    const musicBrainzApi = new MusicBrainzApi({disableRateLimiting: true});
+    const {httpClient} = musicBrainzApi as unknown as {httpClient: HttpClient};
+    sinon.stub(httpClient, 'get').resolves(new Response(
+      JSON.stringify({error: 'Service unavailable'}),
+      {status: 503, statusText: 'Service Unavailable'}
+    ));
+
+    let caughtError: unknown;
+    try {
+      await musicBrainzApi.restGet('/artist/test');
+    } catch (error) {
+      caughtError = error;
+    }
+
+    assert.instanceOf(caughtError, MusicBrainzApiError);
+    assert.strictEqual((caughtError as MusicBrainzApiError).status, 503);
+    assert.strictEqual((caughtError as MusicBrainzApiError).message, 'MusicBrainz request failed (503): Service unavailable');
+  });
+});


### PR DESCRIPTION
## Summary

Improve HTTP retry behavior to prevent unbounded or overly aggressive retry loops.

- Count every HTTP request attempt, including connection resets.
- Reject non-finite retry limits.
- Increase retry delays linearly after each failed attempt.
- Preserve the final connection error or HTTP response.
- Treat final non-successful MusicBrainz responses as API errors.
- Cancel discarded response bodies before retrying.
- Add detailed retry diagnostics.
- Forward the GitHub Actions `DEBUG` variable to test runs.

## Retry schedule

Using the default 500 ms base delay and ten attempts, retries wait:

```text
500 ms, 1,000 ms, 1,500 ms, …, 4,500 ms
```

The maximum cumulative retry delay is 22.5 seconds.

This gives MusicBrainz more recovery time after `429`, `503`, or connection-reset failures without allowing the retry loop to run indefinitely.

To enable retry diagnostics in CI, configure the repository variable:

```text
DEBUG=musicbrainz-api:http-client
```

## Testing

Added focused coverage for:

- Successful recovery after `ECONNRESET`.
- Rethrowing the final connection error.
- Exhausted `429` and `503` responses.
- Increasing retry delays.
- Response-body cancellation.
- Non-finite retry limits.
- Final MusicBrainz API error handling.

All eight focused retry tests pass.